### PR TITLE
Fixes dialyzer issue, jason dep, and usage-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include `:jason` as a runtime dependency instead of dev/test only, fixing compilation warnings in host projects
+- Pass `--no-compile` to `mix dialyzer` to avoid race conditions with parallel analysis stages competing over `_build/dev`
+- Mark tests using `File.cd!` as `async: false` to prevent intermittent compilation failures from global working directory changes
+
+### Changed
+
+- Updated `usage-rules.md` to instruct LLMs not to truncate `mix quality` output
+
 ## [0.3.0] - 2026-02-03
 
 ### Added

--- a/lib/ex_quality/stages/dialyzer.ex
+++ b/lib/ex_quality/stages/dialyzer.ex
@@ -20,7 +20,7 @@ defmodule ExQuality.Stages.Dialyzer do
     start_time = System.monotonic_time(:millisecond)
 
     {output, exit_code} =
-      System.cmd("mix", ["dialyzer"],
+      System.cmd("mix", ["dialyzer", "--no-compile"],
         env: [{"MIX_ENV", "dev"}],
         stderr_to_stdout: true
       )

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule ExQuality.MixProject do
       {:doctor, "~> 0.21", only: :dev},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false},
       {:excoveralls, "~> 0.18", only: :test},
-      {:jason, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:jason, "~> 1.4"},
       {:mimic, "~> 1.7", only: :test},
       {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false}
     ]

--- a/test/ex_quality/init/dep_installer_test.exs
+++ b/test/ex_quality/init/dep_installer_test.exs
@@ -1,5 +1,7 @@
 defmodule ExQuality.Init.DepInstallerTest do
-  use ExUnit.Case, async: true
+  # async: false because File.cd! changes the OS process working directory,
+  # which can cause race conditions with the parallel compiler.
+  use ExUnit.Case, async: false
 
   alias ExQuality.Init.DepInstaller
 

--- a/test/ex_quality/init/project_config_test.exs
+++ b/test/ex_quality/init/project_config_test.exs
@@ -1,5 +1,7 @@
 defmodule ExQuality.Init.ProjectConfigTest do
-  use ExUnit.Case, async: true
+  # async: false because File.cd! changes the OS process working directory,
+  # which can cause race conditions with the parallel compiler.
+  use ExUnit.Case, async: false
 
   test "adds test_coverage config to mix.exs when not present" do
     in_tmp_dir(fn ->

--- a/test/ex_quality/stages/dialyzer_test.exs
+++ b/test/ex_quality/stages/dialyzer_test.exs
@@ -7,7 +7,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - no warnings" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         output = """
         Finding suitable PLTs
         Checking PLT...
@@ -46,7 +46,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - warnings found" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         output = """
         Proceeding with analysis...
 
@@ -87,7 +87,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - single warning" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         output = """
         lib/my_app/user.ex:42:no_return
         Function create/1 has no local return.
@@ -113,7 +113,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - with skipped files" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         output = """
         Could not get Core Erlang code for: /path/to/beam/file.beam
         Recompile with +debug_info or analyze the .erl file instead
@@ -140,7 +140,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - timing" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         Process.sleep(10)
         {"Total errors: 0", 0}
       end)
@@ -159,7 +159,7 @@ defmodule ExQuality.Stages.DialyzerTest do
   describe "run/1 - configuration" do
     setup do
       System
-      |> expect(:cmd, fn "mix", ["dialyzer"], _opts ->
+      |> expect(:cmd, fn "mix", ["dialyzer", "--no-compile"], _opts ->
         {"Total errors: 0", 0}
       end)
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -44,7 +44,6 @@ mix quality --quick
 - **Use during**: Active development, frequent changes, implementing features
 - **Runs**: format, compile (dev+test), credo, dependencies, tests, doctor/gettext
 - **Skips**: dialyzer (slow), coverage enforcement
-- **Speed**: ~5 seconds typically
 
 ### Full mode (verification)
 ```bash
@@ -96,6 +95,20 @@ Create `.quality.exs` in project root:
     audit: false  # Skip security audit
   ]
 ]
+```
+
+## Important: Do Not Truncate Output
+
+Do not pipe `mix quality` output through `tail`, `head`, or any truncation. The tool already captures and manages output to present only the minimal result needed. Truncating may hide critical failure details, file:line references, and summary information.
+
+```bash
+# Correct
+mix quality
+mix quality --quick
+
+# Wrong - do not truncate
+mix quality | tail -50
+mix quality 2>&1 | tail -100
 ```
 
 ## Working with ExQuality Output


### PR DESCRIPTION
- Pass --no-compile to mix dialyzer to avoid race conditions with parallel analysis stages competing over _build/dev
- Include jason as a runtime dependency instead of dev/test only, fixing compilation warnings in host projects
- Mark tests using File.cd! as async: false to prevent intermittent compilation failures from global working directory changes
- Update usage-rules.md to instruct LLMs not to truncate output

Closes #31
Closes #32
Closes #33