### PR TITLE
Fix umbrella correctness issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dialyzer could report `✓ No warnings` on a project with 110 real warnings.** The Gettext stage ran `mix gettext.extract --merge`, which recompiles the project, alongside the analysis stages that read the same build. Dialyzer, invoked with `--no-compile`, hit `Could not get Core Erlang code` and produced nothing, and the debug_info escape hatch promoted that to a pass
+- Dialyzer now separates "ran and found nothing" from "never ran" by whether dialyxir printed its own `Total errors:` tally, and reports the second as a failure (`Analysis did not complete (build changed under it? see output)`) rather than a pass
+- The Gettext stage found no `.po` files in an umbrella and reported `All translations complete` having read nothing. It now looks under every child app as well as the root, and reports `:skipped` with the reason when it examined no files
+- The Gettext stage rejected every path containing `/en/` and every `errors.po` invisibly, so a project whose only locale was `en` had every file filtered out and still went green
+- Dialyzer findings in an umbrella carried `app: null` and an app-relative `file` that did not open from the umbrella root. Each path is now resolved against the child apps by existence; an ambiguous path is left alone rather than guessed at
+- A failing test suite came back with no findings and the whole run log in `output`. Each ExUnit failure is now parsed into a finding with `file`, `line`, `app`, the test module and the assertion message
+
+### Changed
+
+- **The Gettext stage no longer writes to your repository.** `mix gettext.extract --merge` rewrote `.pot`/`.po` files and left the dev build inconsistent enough that the next `mix compile --warnings-as-errors` failed. It is now opt-in with `gettext: [extract: true]`, and the stage reads the committed files as they stand
+- Gettext reports `%ExQuality.Finding{}` structs with app attribution rather than a hand-built prose string, so its failures route like every other stage's
+- Gettext's source locale is configurable (`gettext: [source_locale: "en"]`), as is the excluded basename list (`gettext: [exclude: ["errors.po"]]`)
+
 ### Added
 
+- **Mix alias detection.** ExQuality shells out to the real `mix credo`, `mix dialyzer`, `mix format`, `mix sobelow`, `mix deps.unlock` and `mix test.coverage`, and Mix resolves aliases before tasks. A project that aliases one of those names silently changed what the stage measured: `mix sobelow` ran the alias, ignored every switch and wrote no report; `mix test.coverage` ran the entire suite a second time before aggregating. Those stages now refuse to run and name the alias (`✗ Sobelow: mix sobelow is aliased in mix.exs`). `mix test` is the deliberate exception, since a `test:` alias does the setup the suite needs
+- `ExQuality.Aliases`, with `shadowing?/1` and `shadowed/2`
+- Stages declare whether they read the build or write to it (`stage_kind/1`, `ExQuality.Stage.kind/2`). Writers run serialized before the parallel readers, the way compilation already gates the run
 - A project mark under `assets/`: an SVG with a transparent surround, so it reads on a light or a dark background, plus PNG renders from 512 down to 32. It is the README's header, and the published docs' logo and favicon. The assets are not shipped in the package: HexDocs is built from the checkout at publish time, so nothing downloading the dependency needs them
 
 ## [0.7.0] - 2026-08-01

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ nothing to switch on.
 | Dialyzer | `mix dialyzer --format short --format dialyxir` | `:dialyxir` |
 | Dependencies | `mix deps.unlock --check-unused`, `mix deps.audit --format json` | always; audit needs `:mix_audit` |
 | Doctor | `mix doctor` | `:doctor` |
-| Gettext | `mix gettext.extract --merge`, then reads the `.po` files | `:gettext` |
+| Gettext | reads the `.po` files | `:gettext` |
 | Sobelow | `mix sobelow` | `:sobelow` |
 | Tests | `mix test` | always |
 | Coverage | `mix coveralls`, or `mix test --cover` | `:excoveralls`, or a threshold in `test_coverage` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,14 @@ A keyword list at the project root. Every key is optional.
   ],
 
   gettext: [
-    enabled: :auto
+    enabled: :auto,
+    # The locale the source is written in, whose .po files are not checked.
+    source_locale: "en",
+    # Basenames to skip. Phoenix generates errors.po with empty entries.
+    exclude: ["errors.po"],
+    # Run `mix gettext.extract --merge` first. It writes to the repository and
+    # recompiles the project, so the run serialises this stage when it is on.
+    extract: false
   ],
 
   sobelow: [

--- a/docs/stages.md
+++ b/docs/stages.md
@@ -113,13 +113,48 @@ project's `.doctor.exs`.
 
 ## Gettext
 
-Runs `mix gettext.extract --merge`, then reads the resulting `.po` files for
-untranslated and fuzzy entries.
+Reads the project's `.po` files for untranslated and fuzzy entries, under every
+umbrella child app as well as the root, and reports each one at its `msgid`.
 
 ```
-✓ Gettext: All translations complete (1.1s)
-✗ Gettext: 4 missing, 2 fuzzy translation(s)
+✓ Gettext: All translations complete (12 files) (30ms)
+✗ Gettext: 4 missing, 2 fuzzy translations
+○ Gettext: skipped (no .po files found)
 ```
+
+Files in the source locale are not checked, because the source locale is
+untranslated by definition. It is `"en"` unless `gettext: [source_locale: ...]`
+says otherwise, and `errors.po` is excluded for the same reason. A run left
+with nothing to read reports itself as skipped rather than complete.
+
+This stage does not run `mix gettext.extract --merge`. That task writes: it
+rewrites `.pot` and `.po` files, and it compiles the project to do it, which
+changes the build the other stages are reading. `gettext: [extract: true]` opts
+back in, and the run then serialises the stage rather than running it alongside
+the readers.
+
+No other stage can write to your repository.
+
+## Aliased tasks
+
+ExQuality shells out to the real `mix credo`, `mix dialyzer`, `mix format`,
+`mix sobelow`, `mix deps.unlock` and `mix test.coverage`, and reads what they
+print. Mix resolves aliases before tasks, so a project that defines an alias
+with one of those names silently changes what the stage measures.
+
+A stage checks before shelling out, and refuses rather than reporting a number
+about a command it did not issue:
+
+```
+✗ Format: mix format is aliased in mix.exs
+✗ Sobelow: mix sobelow is aliased in mix.exs
+```
+
+Rename the alias (`sobelow.all` is the usual choice) and point your own scripts
+at the new name.
+
+`mix test` is the deliberate exception: a `test:` alias that runs migrations
+first is near-universal, and running it is what the suite needs.
 
 ## Sobelow
 

--- a/docs/umbrella.md
+++ b/docs/umbrella.md
@@ -55,6 +55,50 @@ separately, the lowest leads and the per-app numbers are reported alongside it.
 per child app that uses Phoenix, and tags each finding with the app it came
 from.
 
+## Dialyzer
+
+One analysis runs from the umbrella root, but dialyxir prints each path
+relative to the child app it found the file in, and there are no `==> app`
+headers to attribute from. A finding reading `lib/user.ex` does not open from
+the directory the report was generated in.
+
+ExQuality resolves each path against the child apps by looking for the file.
+Exactly one app has it: the path is rewritten to `apps/<app>/lib/user.ex` and
+`app` is set. Two apps have the same relative path, or none does: both are left
+as dialyxir reported them, because a wrong app is worse than no app.
+
+## Gettext
+
+An umbrella root has no `priv/` of its own; the translations live in
+`apps/*/priv/gettext`. ExQuality looks under every child app as well as the
+root, and tags each finding with its app.
+
+A run that found no `.po` files reports itself as skipped with the reason,
+rather than as a clean bill of health for files it never read.
+
+## Aliases
+
+The task names ExQuality shells out to are the ones umbrella roots most like to
+alias, because the root is where a project puts the command that fans out over
+its apps:
+
+```elixir
+aliases: [
+  sobelow: ["cmd --app web mix sobelow --config"],
+  "test.coverage": ["test --cover --export-coverage default", "test.coverage"]
+]
+```
+
+Mix resolves aliases before tasks, so both of those change what the stage
+measures: the first ignores every switch and writes no report, the second runs
+the whole suite a second time before aggregating. ExQuality checks before
+shelling out and reports the alias by name instead of running it. Rename the
+alias (`sobelow.all` is the usual choice) and point your own scripts at the new
+name.
+
+`test` is the exception. A `test:` alias that runs migrations first is
+near-universal, and running it is what the suite needs.
+
 ## Configuration
 
 `.quality.exs` is read from the project root. An umbrella child with no file of

--- a/lib/ex_quality/aliases.ex
+++ b/lib/ex_quality/aliases.ex
@@ -1,0 +1,88 @@
+defmodule ExQuality.Aliases do
+  @moduledoc """
+  Detects when a project's Mix aliases shadow a task a stage shells out to.
+
+  Mix resolves aliases before tasks, so `mix sobelow` in a project whose
+  `mix.exs` says
+
+      aliases: [sobelow: ["cmd --app web mix sobelow --config"]]
+
+  runs the alias and ignores every switch a stage passed. The stage then
+  measures something other than what it asked for, and the failure is quiet:
+  a report that was never written, or a suite run twice and counted twice.
+
+  The task names ExQuality shells out to are exactly the ones projects most
+  like to alias - `credo`, `dialyzer`, `format`, `sobelow`, `deps.unlock`,
+  `test.coverage` - so a stage whose parsing depends on its exact invocation
+  asks here first, and refuses to run rather than reporting a number about a
+  command it did not issue.
+
+  Detection, not bypass: silently ignoring a project's alias is its own
+  surprise, and naming it gives the reader the choice.
+
+  ## `test` is deliberately not on the list
+
+  A `test:` alias (`["ecto.create --quiet", "ecto.migrate", "test"]`) is
+  near-universal and running it is correct - it does the setup the suite needs.
+  `test.coverage` is different: it is pure aggregation, and an alias on it runs
+  the suite a second time before aggregating.
+  """
+
+  alias ExQuality.Stage
+
+  @doc """
+  Returns true when the project defines a Mix alias with this task's name.
+
+  Safe to call outside a Mix project, where there are no aliases to shadow
+  anything.
+
+      iex> ExQuality.Aliases.shadowing?("no.such.task")
+      false
+  """
+  @spec shadowing?(String.t() | atom()) :: boolean()
+  def shadowing?(task) do
+    Keyword.has_key?(aliases(), key(task))
+  end
+
+  @doc """
+  Returns an `:error` result for a stage that will not run because its task is
+  aliased, naming the alias and what to do about it.
+
+  The suggested rename is `<task>.all`, which is a name Mix will not resolve to
+  the real task and which reads as "the project's own wrapper".
+
+      iex> result = ExQuality.Aliases.shadowed("Sobelow", "sobelow")
+      iex> result.summary
+      "mix sobelow is aliased in mix.exs"
+  """
+  @spec shadowed(String.t(), String.t()) :: Stage.result()
+  def shadowed(name, task) do
+    %{
+      name: name,
+      status: :error,
+      output: """
+      ExQuality runs `mix #{task}` and reads what it prints, but this project
+      defines a Mix alias named `#{task}` in mix.exs. Mix resolves aliases
+      before tasks, so the alias runs instead and the switches this stage
+      passes are ignored.
+
+      Rename the alias - `#{task}.all` is the usual choice - and point your own
+      scripts at the new name.
+      """,
+      findings: [],
+      stats: %{},
+      summary: "mix #{task} is aliased in mix.exs",
+      duration_ms: 0
+    }
+  end
+
+  defp aliases do
+    case Mix.Project.get() do
+      nil -> []
+      _module -> Mix.Project.config()[:aliases] || []
+    end
+  end
+
+  defp key(task) when is_atom(task), do: task
+  defp key(task) when is_binary(task), do: String.to_atom(task)
+end

--- a/lib/ex_quality/config.ex
+++ b/lib/ex_quality/config.ex
@@ -47,6 +47,11 @@ defmodule ExQuality.Config do
   - `dependencies.check_unused` - Check for unused dependencies (default: true)
   - `dependencies.audit` - Run security audit if available (default: :auto)
   - `doctor.summary_only` - Show only summary (default: false)
+  - `gettext.source_locale` - The locale the source is written in, whose `.po`
+    files are not checked (default: `"en"`)
+  - `gettext.exclude` - Basenames to skip (default: `["errors.po"]`)
+  - `gettext.extract` - Run `mix gettext.extract --merge` first, which writes to
+    the repository and recompiles the project (default: false)
   - `sobelow.exit` - Confidence level that blocks, when `.sobelow-conf` sets no
     `exit:` of its own (default: "medium")
   - `sobelow.show_informational` - Render findings below that level as well as
@@ -76,7 +81,14 @@ defmodule ExQuality.Config do
       summary_only: false
     ],
     gettext: [
-      enabled: :auto
+      enabled: :auto,
+      # The locale the source is written in. Its .po files are untranslated by
+      # definition, so checking them would report every entry in them.
+      source_locale: "en",
+      exclude: ["errors.po"],
+      # `mix gettext.extract --merge` writes to the repository and recompiles
+      # the project, so it is opt-in rather than something a checker does.
+      extract: false
     ],
     sobelow: [
       enabled: :auto,

--- a/lib/ex_quality/stage.ex
+++ b/lib/ex_quality/stage.ex
@@ -26,6 +26,20 @@ defmodule ExQuality.Stage do
 
   alias ExQuality.Finding
 
+  @typedoc """
+  Whether a stage reads the build or writes to it.
+
+  The analysis phase runs its stages concurrently, which is only safe while
+  every one of them is a reader. A stage that recompiles the project or
+  rewrites files under `_build` invalidates the beams the others are part-way
+  through reading, and the reader that notices reports a failure that has
+  nothing to do with the code. Writers are run on their own, before the
+  readers, for the same reason compilation is a serialized gate.
+
+  A stage that does not say is a `:reader`.
+  """
+  @type kind :: :reader | :writer
+
   @type stats :: %{
           optional(:test_count) => non_neg_integer(),
           optional(:passed_count) => non_neg_integer(),
@@ -41,6 +55,9 @@ defmodule ExQuality.Stage do
           optional(:vulnerabilities) => non_neg_integer(),
           optional(:vulnerabilities_by_severity) => [{String.t(), non_neg_integer()}],
           optional(:files_formatted) => non_neg_integer(),
+          optional(:missing_translations) => non_neg_integer(),
+          optional(:fuzzy_translations) => non_neg_integer(),
+          optional(:file_count) => non_neg_integer(),
           optional(:finding_count) => non_neg_integer(),
           optional(:blocking_count) => non_neg_integer(),
           optional(:informational_count) => non_neg_integer(),
@@ -65,6 +82,30 @@ defmodule ExQuality.Stage do
   """
   @spec findings(map()) :: [Finding.t()]
   def findings(result), do: Map.get(result, :findings, [])
+
+  @doc """
+  Returns whether a stage module reads the build or writes to it.
+
+  A module says so by exporting `stage_kind/1`, which is given the run's
+  config because a stage can be a writer only in some configurations. A module
+  that does not export it is a `:reader`, so classifying a stage is one
+  function on the stage that has something to declare rather than a line on
+  every stage that does not.
+
+      iex> ExQuality.Stage.kind(ExQuality.Stages.Credo, [])
+      :reader
+
+      iex> ExQuality.Stage.kind(ExQuality.Stages.Gettext, gettext: [extract: true])
+      :writer
+  """
+  @spec kind(module(), keyword()) :: kind()
+  def kind(module, config) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :stage_kind, 1) do
+      module.stage_kind(config)
+    else
+      :reader
+    end
+  end
 
   @doc """
   Builds a `:skipped` result for a stage that was considered and not run.

--- a/lib/ex_quality/stages/credo.ex
+++ b/lib/ex_quality/stages/credo.ex
@@ -21,6 +21,7 @@ defmodule ExQuality.Stages.Credo do
   Note: Credo does not support auto-fix. All issues must be manually resolved.
   """
 
+  alias ExQuality.Aliases
   alias ExQuality.Finding
   alias ExQuality.Json
   alias ExQuality.Umbrella
@@ -43,6 +44,14 @@ defmodule ExQuality.Stages.Credo do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
+    if Aliases.shadowing?("credo") do
+      Aliases.shadowed("Credo", "credo")
+    else
+      check(config)
+    end
+  end
+
+  defp check(config) do
     start_time = System.monotonic_time(:millisecond)
 
     credo_config = Keyword.get(config, :credo, [])

--- a/lib/ex_quality/stages/dependencies.ex
+++ b/lib/ex_quality/stages/dependencies.ex
@@ -31,6 +31,7 @@ defmodule ExQuality.Stages.Dependencies do
   in full instead.
   """
 
+  alias ExQuality.Aliases
   alias ExQuality.Finding
   alias ExQuality.Json
   alias ExQuality.Umbrella
@@ -49,6 +50,14 @@ defmodule ExQuality.Stages.Dependencies do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
+    if Aliases.shadowing?("deps.unlock") do
+      Aliases.shadowed("Dependencies", "deps.unlock")
+    else
+      check(config)
+    end
+  end
+
+  defp check(config) do
     start_time = System.monotonic_time(:millisecond)
 
     deps_config = Keyword.get(config, :dependencies, [])

--- a/lib/ex_quality/stages/dialyzer.ex
+++ b/lib/ex_quality/stages/dialyzer.ex
@@ -61,6 +61,7 @@ defmodule ExQuality.Stages.Dialyzer do
   alone rather than guessed at.
   """
 
+  alias ExQuality.Aliases
   alias ExQuality.Finding
   alias ExQuality.OutputCollector
   alias ExQuality.Plt
@@ -80,6 +81,14 @@ defmodule ExQuality.Stages.Dialyzer do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(_config) do
+    if Aliases.shadowing?("dialyzer") do
+      Aliases.shadowed("Dialyzer", "dialyzer")
+    else
+      analyse()
+    end
+  end
+
+  defp analyse do
     start_time = System.monotonic_time(:millisecond)
 
     {output, exit_code} = run_dialyzer()

--- a/lib/ex_quality/stages/dialyzer.ex
+++ b/lib/ex_quality/stages/dialyzer.ex
@@ -36,6 +36,29 @@ defmodule ExQuality.Stages.Dialyzer do
   A build is reported, not penalised: the analysis that follows one is as good
   as any other, so the stage still passes or fails on its warnings alone.
   `mix quality.plt` is the way to pay for the build outside the run.
+
+  ## Analyses that never ran
+
+  `--no-compile` assumes the beams hold still. If something rewrites them while
+  dialyzer is reading them, dialyzer stops with
+  `Could not get Core Erlang code for: ... Recompile with +debug_info` and
+  reports nothing at all.
+
+  That is the same message a genuine no-debug_info dependency produces, and
+  that one is worth passing over. The two are told apart by whether the
+  analysis reached its own summary: dialyxir prints `Total errors: N` when it
+  finished, even for N = 0. No summary means the analysis did not complete, and
+  a stage that parsed zero findings because it never looked is not a stage that
+  passed.
+
+  ## Umbrellas
+
+  dialyxir prints paths relative to each child app while running one analysis
+  from the umbrella root, and there are no `==> app` headers to attribute from.
+  A path like `lib/user.ex` therefore does not open from where the report was
+  generated. Each one is resolved against the child apps by existence: exactly
+  one match rewrites the path and names the app, and anything else is left
+  alone rather than guessed at.
   """
 
   alias ExQuality.Finding
@@ -70,25 +93,35 @@ defmodule ExQuality.Stages.Dialyzer do
         result(output, :ok, [], summary("No warnings", plt_built?), plt_built?, duration_ms)
 
       {_exit_code, []} ->
-        # Non-zero exit but no warnings found - could be PLT building or other issue
-        # Check if it's the common "Could not get Core Erlang code" error for Mix tasks
-        if debug_info_error?(output) do
-          # This is a known issue with Mix tasks not having debug_info
-          # Treat as success if there are no actual type warnings
-          summary = summary("No warnings", plt_built?, "some files skipped")
-
-          result(output, :ok, [], summary, plt_built?, duration_ms)
-        else
-          # Unknown error with no warnings - report as error
-          summary = summary("Check failed", plt_built?, "see output")
-
-          result(output, :error, [], summary, plt_built?, duration_ms)
-        end
+        empty_result(output, plt_built?, duration_ms)
 
       {_exit_code, findings} ->
         summary = summary(format_warnings(length(findings)), plt_built?)
 
         result(output, :error, findings, summary, plt_built?, duration_ms)
+    end
+  end
+
+  # A non-zero exit with nothing parsed is either "a few files had no
+  # debug_info", which is fine, or "the analysis never ran", which is not. The
+  # summary line dialyxir prints when it finishes is what tells them apart.
+  defp empty_result(output, plt_built?, duration_ms) do
+    cond do
+      debug_info_error?(output) and analysis_completed?(output) ->
+        summary = summary("No warnings", plt_built?, "some files skipped")
+
+        result(output, :ok, [], summary, plt_built?, duration_ms)
+
+      debug_info_error?(output) ->
+        summary =
+          summary("Analysis did not complete", plt_built?, "build changed under it? see output")
+
+        result(output, :error, [], summary, plt_built?, duration_ms)
+
+      true ->
+        summary = summary("Check failed", plt_built?, "see output")
+
+        result(output, :error, [], summary, plt_built?, duration_ms)
     end
   end
 
@@ -155,14 +188,14 @@ defmodule ExQuality.Stages.Dialyzer do
   defp finding(line, apps) do
     case Regex.run(@warning_regex, line) do
       [_match, file, line_no, column, warning, message] ->
-        file = Finding.relative_path(file)
+        {file, app} = file |> Finding.relative_path() |> locate(apps)
 
         [
           %Finding{
             file: file,
             line: String.to_integer(line_no),
             column: position(column),
-            app: Umbrella.app_for_path(file, apps),
+            app: app,
             # Every dialyzer warning fails the stage, so none of them is
             # informational.
             severity: :error,
@@ -181,10 +214,32 @@ defmodule ExQuality.Stages.Dialyzer do
   defp position(""), do: nil
   defp position(column), do: String.to_integer(column)
 
+  # A path that already names its app is taken as it stands. One that does not
+  # is an app-relative path from an umbrella run, and the app it belongs to is
+  # the one that has the file. Two apps with the same relative path is
+  # ambiguous, and a wrong app is worse than none, so it is left alone.
+  defp locate(file, apps) do
+    case Umbrella.app_for_path(file, apps) do
+      nil -> resolve_in_apps(file, apps)
+      app -> {file, app}
+    end
+  end
+
+  defp resolve_in_apps(file, apps) do
+    case Enum.filter(apps, fn {_app, path} -> File.exists?(Path.join(path, file)) end) do
+      [{app, path}] -> {Path.join(path, file), app}
+      _none_or_many -> {file, nil}
+    end
+  end
+
   defp debug_info_error?(output) do
     String.contains?(output, "Could not get Core Erlang code") and
       String.contains?(output, "Recompile with +debug_info")
   end
+
+  # dialyxir closes a completed analysis with its own tally, whatever the tally
+  # is. Its absence is the difference between "found nothing" and "never ran".
+  defp analysis_completed?(output), do: String.contains?(output, "Total errors:")
 
   defp format_warnings(1), do: "1 warning"
   defp format_warnings(count), do: "#{count} warnings"

--- a/lib/ex_quality/stages/format.ex
+++ b/lib/ex_quality/stages/format.ex
@@ -33,10 +33,15 @@ defmodule ExQuality.Stages.Format do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(_config) do
-    if formatter_config?() do
-      format()
-    else
-      ExQuality.Stage.skipped("Format", "no .formatter.exs")
+    cond do
+      ExQuality.Aliases.shadowing?("format") ->
+        ExQuality.Aliases.shadowed("Format", "format")
+
+      formatter_config?() ->
+        format()
+
+      true ->
+        ExQuality.Stage.skipped("Format", "no .formatter.exs")
     end
   end
 

--- a/lib/ex_quality/stages/gettext.ex
+++ b/lib/ex_quality/stages/gettext.ex
@@ -1,160 +1,246 @@
 defmodule ExQuality.Stages.Gettext do
   @moduledoc """
-  Checks translation completeness using gettext.
+  Checks translation completeness by reading the project's `.po` files.
 
-  Runs `mix gettext.extract --merge` then scans .po files for:
-  - Missing translations (empty msgstr)
-  - Fuzzy translations (marked with #, fuzzy)
+  Reports two kinds of finding, one per untranslated or fuzzy entry, each with
+  the file, the line of its `msgid`, and the app it belongs to:
 
-  Provides actionable output with file:line and msgid for each issue.
+  - missing translations (an empty `msgstr`)
+  - fuzzy translations (marked `#, fuzzy`)
 
   This stage is automatically enabled only if `:gettext` is in deps.
+
+  ## What it reads
+
+  Translations live in `priv/` under whichever project declares the backend, so
+  the files are found with a wildcard over the umbrella's child apps as well as
+  the root. An umbrella root has no `priv/` of its own: a scan of one hardcoded
+  directory there finds nothing, and finding nothing is not the same as finding
+  no problems.
+
+  A run that examined no files reports itself as `:skipped` with the reason,
+  the way an uninstalled tool does. A stage that said nothing would otherwise
+  read as a stage that passed.
+
+  ## The source locale
+
+  A project's source locale is written in the source, so its `.po` files are
+  untranslated by definition and every entry in them would be reported. That
+  locale is `"en"` unless `gettext: [source_locale: "..."]` says otherwise, and
+  a project whose only locale is the source locale is reported as skipped
+  rather than green.
+
+  `errors.po` is excluded for the same reason - Phoenix generates it with empty
+  entries in every locale - and `gettext: [exclude: [...]]` replaces that list.
+
+  ## Extraction
+
+  `mix gettext.extract --merge` writes: it rewrites `.pot` and `.po` files, and
+  it compiles the project to do it. Both are surprises from a checker. A tool
+  that dirties the tree lands in every commit as noise, and a stage that
+  recompiles while the other stages are reading the same build can pull the
+  ground out from under them.
+
+  So it is off by default and this stage reads the committed files as they
+  stand. `gettext: [extract: true]` turns it back on, and the stage then
+  declares itself a writer (`stage_kind/1`) so the run serialises it rather
+  than running it alongside the stages that read the build.
   """
+
+  alias ExQuality.Finding
+  alias ExQuality.Stage
+  alias ExQuality.Umbrella
+
+  @source_locale "en"
+  @exclude ["errors.po"]
+
+  @doc """
+  Says whether this stage writes to the project, so a run can keep it away from
+  the stages that read the build.
+
+  Extraction compiles the project and rewrites translation files, so a stage
+  configured to extract is a `:writer`. Reading `.po` files is not, so the
+  default is `:reader`.
+
+      iex> ExQuality.Stages.Gettext.stage_kind([])
+      :reader
+
+      iex> ExQuality.Stages.Gettext.stage_kind(gettext: [extract: true])
+      :writer
+  """
+  @spec stage_kind(keyword()) :: ExQuality.Stage.kind()
+  def stage_kind(config), do: if(extract?(config), do: :writer, else: :reader)
 
   @doc """
   Runs the gettext stage.
+
+  ## Config options
+
+  - `gettext.source_locale` - the locale the source is written in, whose files
+    are not checked (default: `"en"`)
+  - `gettext.exclude` - basenames to skip (default: `["errors.po"]`)
+  - `gettext.extract` - run `mix gettext.extract --merge` first, writing to the
+    project (default: `false`)
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
-  def run(_config) do
+  def run(config) do
     start_time = System.monotonic_time(:millisecond)
 
-    # Run extraction to ensure .po files are up to date
-    {_output, extract_exit} =
-      System.cmd("mix", ["gettext.extract", "--merge"],
-        env: [{"MIX_ENV", "dev"}],
-        stderr_to_stdout: true
-      )
-
-    duration_ms = System.monotonic_time(:millisecond) - start_time
-
-    if extract_exit != 0 do
-      %{
-        name: "Gettext",
-        status: :error,
-        output: "Gettext extraction failed",
-        stats: %{},
-        summary: "Extraction failed",
-        duration_ms: duration_ms
-      }
-    else
-      check_translations(duration_ms)
+    case extract(config) do
+      :ok -> check_translations(config, start_time)
+      {:error, result} -> result
     end
   end
 
-  defp check_translations(duration_ms) do
-    po_files = find_po_files()
-
-    missing = collect_missing_translations(po_files)
-    fuzzy = collect_fuzzy_translations(po_files)
-
-    total_missing = count_items(missing)
-    total_fuzzy = count_items(fuzzy)
-
-    cond do
-      total_missing > 0 and total_fuzzy > 0 ->
-        missing_output = format_errors("missing", missing)
-        fuzzy_output = format_errors("fuzzy", fuzzy)
-        output = "#{missing_output}\n\n#{fuzzy_output}"
-
-        %{
-          name: "Gettext",
-          status: :error,
-          output: output,
-          stats: %{missing_translations: total_missing, fuzzy_translations: total_fuzzy},
-          summary: "#{total_missing} missing, #{total_fuzzy} fuzzy translation(s)",
-          duration_ms: duration_ms
-        }
-
-      total_missing > 0 ->
-        %{
-          name: "Gettext",
-          status: :error,
-          output: format_errors("missing", missing),
-          stats: %{missing_translations: total_missing},
-          summary: "#{total_missing} missing translation(s)",
-          duration_ms: duration_ms
-        }
-
-      total_fuzzy > 0 ->
-        %{
-          name: "Gettext",
-          status: :error,
-          output: format_errors("fuzzy", fuzzy),
-          stats: %{fuzzy_translations: total_fuzzy},
-          summary: "#{total_fuzzy} fuzzy translation(s)",
-          duration_ms: duration_ms
-        }
-
-      true ->
-        %{
-          name: "Gettext",
-          status: :ok,
-          output: "",
-          stats: %{},
-          summary: "All translations complete",
-          duration_ms: duration_ms
-        }
-    end
-  end
-
-  defp find_po_files do
-    case System.cmd("find", ["priv/gettext", "-name", "*.po"], stderr_to_stdout: true) do
-      {output, 0} ->
-        output
-        |> String.trim()
-        |> String.split("\n")
-        |> Enum.reject(
-          &(&1 == "" or String.contains?(&1, "/en/") or String.contains?(&1, "errors.po"))
+  defp extract(config) do
+    if extract?(config) do
+      {_output, exit_code} =
+        System.cmd("mix", ["gettext.extract", "--merge"],
+          env: [{"MIX_ENV", "dev"}],
+          stderr_to_stdout: true
         )
 
-      _ ->
-        []
+      if exit_code == 0, do: :ok, else: {:error, extraction_failed()}
+    else
+      :ok
     end
   end
 
-  defp collect_missing_translations(po_files) do
-    po_files
-    |> Enum.map(fn file ->
-      {file, find_untranslated_strings_with_lines(file)}
-    end)
-    |> Enum.reject(fn {_file, items} -> items == [] end)
+  defp extraction_failed do
+    %{
+      name: "Gettext",
+      status: :error,
+      output: "Gettext extraction failed",
+      findings: [],
+      stats: %{},
+      summary: "Extraction failed",
+      duration_ms: 0
+    }
   end
 
-  defp collect_fuzzy_translations(po_files) do
-    po_files
-    |> Enum.map(fn file ->
-      {file, find_fuzzy_strings_with_lines(file)}
-    end)
-    |> Enum.reject(fn {_file, items} -> items == [] end)
+  defp extract?(config) do
+    config |> Keyword.get(:gettext, []) |> Keyword.get(:extract, false)
   end
 
-  defp find_untranslated_strings_with_lines(po_file) do
-    case File.read(po_file) do
-      {:ok, content} ->
-        content
-        |> String.split("\n")
-        |> parse_po_for_untranslated_with_lines()
-        |> Enum.reject(fn {_line, msgid} -> msgid == "" end)
+  # Nothing to read is reported as a skip, not a pass, and the two reasons a
+  # project can have nothing to read are different problems with different
+  # fixes, so they are named separately.
+  defp check_translations(config, start_time) do
+    case po_files(config) do
+      {[], reason} ->
+        Stage.skipped("Gettext", reason)
+
+      {files, _reason} ->
+        findings = files |> Enum.flat_map(&file_findings/1) |> Finding.sort()
+        report(findings, length(files), System.monotonic_time(:millisecond) - start_time)
+    end
+  end
+
+  # `{app, file}` pairs: the app is what a reader of a ten-app umbrella needs
+  # in order to know who owns the translation.
+  defp po_files(config) do
+    all =
+      for {app, root} <- roots(),
+          file <- Path.wildcard(Path.join(root, "priv/**/*.po")),
+          do: {app, file}
+
+    case {all, Enum.filter(all, &checked?(&1, config))} do
+      {[], _checked} -> {[], "no .po files found"}
+      {_all, []} -> {[], "no .po files outside the source locale"}
+      {_all, checked} -> {checked, nil}
+    end
+  end
+
+  defp roots do
+    case Enum.sort(Umbrella.apps_paths()) do
+      [] -> [{nil, "."}]
+      apps -> [{nil, "."} | apps]
+    end
+  end
+
+  defp checked?({_app, file}, config) do
+    gettext = Keyword.get(config, :gettext, [])
+    locale = Keyword.get(gettext, :source_locale, @source_locale)
+    exclude = Keyword.get(gettext, :exclude, @exclude)
+
+    not String.contains?(file, "/#{locale}/") and Path.basename(file) not in exclude
+  end
+
+  defp file_findings({app, file}) do
+    case File.read(file) do
+      {:ok, contents} ->
+        lines = String.split(contents, "\n")
+        path = Finding.relative_path(file)
+
+        Enum.map(untranslated(lines), &finding(&1, path, app, "missing")) ++
+          Enum.map(fuzzy(lines), &finding(&1, path, app, "fuzzy"))
 
       {:error, _reason} ->
         []
     end
   end
 
-  defp parse_po_for_untranslated_with_lines(lines) do
+  defp finding({line, msgid}, file, app, check) do
+    %Finding{
+      file: file,
+      line: line,
+      app: app,
+      severity: :error,
+      check: check,
+      message: "#{check} translation for \"#{truncate_msgid(msgid)}\"",
+      raw: "#{file}:#{line} #{check}: #{msgid}"
+    }
+  end
+
+  defp report(findings, file_count, duration_ms) do
+    {missing, fuzzy} = Enum.split_with(findings, &(&1.check == "missing"))
+
+    %{
+      name: "Gettext",
+      status: if(findings == [], do: :ok, else: :error),
+      output: "",
+      findings: findings,
+      stats: stats(length(missing), length(fuzzy), file_count),
+      summary: summary(length(missing), length(fuzzy), file_count),
+      duration_ms: duration_ms
+    }
+  end
+
+  defp stats(missing, fuzzy, file_count) do
+    %{missing_translations: missing, fuzzy_translations: fuzzy, file_count: file_count}
+  end
+
+  # A clean run says how much it read, because "all translations complete"
+  # over one file and over forty are not the same statement.
+  defp summary(0, 0, file_count), do: "All translations complete (#{files(file_count)})"
+  defp summary(missing, 0, _count), do: "#{missing} missing translation#{plural(missing)}"
+  defp summary(0, fuzzy, _count), do: "#{fuzzy} fuzzy translation#{plural(fuzzy)}"
+
+  defp summary(missing, fuzzy, _count) do
+    "#{missing} missing, #{fuzzy} fuzzy translation#{plural(fuzzy)}"
+  end
+
+  defp files(1), do: "1 file"
+  defp files(count), do: "#{count} files"
+
+  defp plural(1), do: ""
+  defp plural(_count), do: "s"
+
+  defp untranslated(lines) do
     lines
     |> Enum.with_index()
     |> Enum.reduce([], fn {line, index}, acc ->
       add_untranslated_if_empty(line, lines, index, acc)
     end)
     |> Enum.reverse()
+    |> Enum.reject(fn {_line, msgid} -> msgid == "" end)
   end
 
   defp add_untranslated_if_empty(line, lines, index, acc) do
     if String.match?(line, ~r/^msgstr ""$/) do
       case find_msgid_before_line_with_number(lines, index) do
         {msgid, line_num} when msgid != "" -> [{line_num + 1, msgid} | acc]
-        _ -> acc
+        _no_msgid -> acc
       end
     else
       acc
@@ -168,46 +254,26 @@ defmodule ExQuality.Stages.Gettext do
     |> Enum.reverse()
     |> Enum.find(fn {line, _idx} -> String.starts_with?(line, "msgid ") end)
     |> case do
-      nil ->
-        {"", 0}
-
-      {msgid_line, line_num} ->
-        msgid =
-          msgid_line
-          |> String.replace(~r/^msgid "/, "")
-          |> String.replace(~r/"$/, "")
-
-        {msgid, line_num}
+      nil -> {"", 0}
+      {msgid_line, line_num} -> {msgid(msgid_line), line_num}
     end
   end
 
-  defp find_fuzzy_strings_with_lines(po_file) do
-    case File.read(po_file) do
-      {:ok, content} ->
-        content
-        |> String.split("\n")
-        |> parse_po_for_fuzzy_with_lines()
-        |> Enum.reject(fn {_line, msgid} -> msgid == "" end)
-
-      {:error, _reason} ->
-        []
-    end
-  end
-
-  defp parse_po_for_fuzzy_with_lines(lines) do
+  defp fuzzy(lines) do
     lines
     |> Enum.with_index()
     |> Enum.reduce([], fn {line, index}, acc ->
       add_fuzzy_if_marked(line, lines, index, acc)
     end)
     |> Enum.reverse()
+    |> Enum.reject(fn {_line, msgid} -> msgid == "" end)
   end
 
   defp add_fuzzy_if_marked(line, lines, index, acc) do
     if String.match?(line, ~r/^#,.*\bfuzzy\b/) do
       case find_msgid_after_line_with_number(lines, index) do
         {msgid, line_num} when msgid != "" -> [{line_num + 1, msgid} | acc]
-        _ -> acc
+        _no_msgid -> acc
       end
     else
       acc
@@ -220,44 +286,15 @@ defmodule ExQuality.Stages.Gettext do
     |> Enum.with_index(fuzzy_index + 1)
     |> Enum.find(fn {line, _idx} -> String.starts_with?(line, "msgid ") end)
     |> case do
-      nil ->
-        {"", 0}
-
-      {msgid_line, line_num} ->
-        msgid =
-          msgid_line
-          |> String.replace(~r/^msgid "/, "")
-          |> String.replace(~r/"$/, "")
-
-        {msgid, line_num}
+      nil -> {"", 0}
+      {msgid_line, line_num} -> {msgid(msgid_line), line_num}
     end
   end
 
-  defp count_items(file_items) do
-    Enum.sum(Enum.map(file_items, fn {_file, items} -> length(items) end))
-  end
-
-  defp format_errors(type, file_items) do
-    header = "#{String.capitalize(type)} translations:\n"
-
-    file_details =
-      Enum.map_join(file_items, "\n\n", fn {file, items} ->
-        display_file = String.replace_leading(file, "./", "")
-
-        item_details =
-          items
-          |> Enum.take(5)
-          |> Enum.map_join("\n", fn {line, msgid} ->
-            "  #{display_file}:#{line} - \"#{truncate_msgid(msgid)}\""
-          end)
-
-        remaining = length(items) - 5
-        remaining_msg = if remaining > 0, do: "\n  ... and #{remaining} more", else: ""
-
-        "#{display_file} (#{length(items)} #{type}):\n#{item_details}#{remaining_msg}"
-      end)
-
-    "#{header}#{file_details}"
+  defp msgid(line) do
+    line
+    |> String.replace(~r/^msgid "/, "")
+    |> String.replace(~r/"$/, "")
   end
 
   defp truncate_msgid(msgid) do

--- a/lib/ex_quality/stages/sobelow.ex
+++ b/lib/ex_quality/stages/sobelow.ex
@@ -50,6 +50,7 @@ defmodule ExQuality.Stages.Sobelow do
   take on.
   """
 
+  alias ExQuality.Aliases
   alias ExQuality.Finding
   alias ExQuality.Umbrella
 
@@ -71,6 +72,14 @@ defmodule ExQuality.Stages.Sobelow do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
+    if Aliases.shadowing?("sobelow") do
+      Aliases.shadowed("Sobelow", "sobelow")
+    else
+      scan_project(config)
+    end
+  end
+
+  defp scan_project(config) do
     start_time = System.monotonic_time(:millisecond)
     scans = scan_all(targets(), config)
     duration_ms = System.monotonic_time(:millisecond) - start_time

--- a/lib/ex_quality/stages/test.ex
+++ b/lib/ex_quality/stages/test.ex
@@ -52,6 +52,7 @@ defmodule ExQuality.Stages.Test do
   can hold a low module and there is nothing to do about it.
   """
 
+  alias ExQuality.Aliases
   alias ExQuality.Finding
   alias ExQuality.Umbrella
 
@@ -71,9 +72,24 @@ defmodule ExQuality.Stages.Test do
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
+    mode = coverage_mode(config)
+
+    if aggregating?(mode) and Aliases.shadowing?("test.coverage") do
+      Aliases.shadowed("Tests", "test.coverage")
+    else
+      test(config, mode)
+    end
+  end
+
+  # A `test:` alias is near-universal and running it is correct: it does the
+  # setup the suite needs. `mix test.coverage` is pure aggregation, so an alias
+  # on that one runs the whole suite a second time before aggregating, and the
+  # only trace is a doubled test count and a doubled wall clock.
+  defp aggregating?(mode), do: mode == :native and Umbrella.umbrella?()
+
+  defp test(config, mode) do
     start_time = System.monotonic_time(:millisecond)
 
-    mode = coverage_mode(config)
     test_args = config |> Keyword.get(:test, []) |> Keyword.get(:args, [])
 
     {output, exit_code} = run_tests(mode, test_args)

--- a/lib/ex_quality/stages/test.ex
+++ b/lib/ex_quality/stages/test.ex
@@ -45,6 +45,20 @@ defmodule ExQuality.Stages.Test do
 
   ## Findings
 
+  A failing test is the most common thing a run has to hand off, so each one is
+  parsed into a finding carrying the file, the line the test is defined at, the
+  app, the test module and the assertion message. The alternative is 30 KB of
+  run log with one failure buried in it.
+
+  The failure block's own `stacktrace:` lines are relative to the app, while
+  the header line under the test's name is relative to the umbrella root, so
+  the header line is what is read: a path that does not open from where the
+  report was generated cannot be routed anywhere.
+
+  The parse is used only when it accounts for every failure the suite counted.
+  Three findings for four failures would read as the complete list, which is
+  worse than showing the log; a short parse falls back to `output` in full.
+
   A failing coverage check reports the modules under the threshold, not the
   whole table. A 400-module umbrella prints 400 rows; the handful below the line
   are the ones a reader acts on. Modules are reported only when the run actually
@@ -178,7 +192,9 @@ defmodule ExQuality.Stages.Test do
       |> merge_test_counts(scan.tests)
       |> merge_coverage(scan, mode)
 
-    %{stats: stats, findings: findings(stats, scan)}
+    findings = failure_findings(output, stats) ++ findings(stats, scan)
+
+    %{stats: stats, findings: Finding.sort(findings)}
   end
 
   # Walks the output once, attributing every summary line to the app whose
@@ -232,6 +248,115 @@ defmodule ExQuality.Stages.Test do
 
   defp add_coverage(acc, percentage) do
     %{acc | coverage: [%{app: acc.app, coverage: to_float(percentage)} | acc.coverage]}
+  end
+
+  # ExUnit opens each failure with a numbered header naming the test and its
+  # module, and follows it immediately with the file and line the test is
+  # defined at.
+  @failure_header_regex ~r/^\s*\d+\)\s+(\w+)\s+(.+?)\s+\(([A-Z]\S*)\)\s*$/
+  @failure_location_regex ~r/^\s*(\S+\.exs?):(\d+)\s*$/
+  # Everything ExUnit prints about *how* the assertion failed rather than
+  # *what* went wrong. The lines before these are the message.
+  @failure_detail_regex ~r/^\s*(code|stacktrace|left|right|arguments|The following output was logged):/
+
+  # A failing test is the most common thing a run has to hand off, so it is
+  # parsed into a finding a caller can route rather than left in 30 KB of run
+  # log. The whole log is still carried in `output`.
+  #
+  # Only a parse that accounts for every failure the suite reported is used. A
+  # partial one would render three findings for four failures and read as the
+  # complete list, which is worse than showing the log.
+  defp failure_findings(output, %{failed_count: failed}) when failed > 0 do
+    apps = Umbrella.apps_paths()
+
+    findings =
+      output
+      |> String.split("\n")
+      |> Enum.reduce(%{state: :scanning, failures: []}, &failure_line/2)
+      |> close_failure()
+      |> Map.fetch!(:failures)
+      |> Enum.reverse()
+      |> Enum.map(&failure_finding(&1, apps))
+
+    if length(findings) == failed, do: findings, else: []
+  end
+
+  defp failure_findings(_output, _stats), do: []
+
+  defp failure_line(line, %{state: :scanning} = acc) do
+    case Regex.run(@failure_header_regex, line) do
+      [_line, kind, name, module] ->
+        failure = %{
+          kind: kind,
+          name: name,
+          module: module,
+          file: nil,
+          line: nil,
+          message: [],
+          raw: [line]
+        }
+
+        %{acc | state: failure}
+
+      nil ->
+        acc
+    end
+  end
+
+  # The location is on the line right after the header. Anything else there
+  # means this was not a failure block after all.
+  defp failure_line(line, %{state: %{file: nil} = failure} = acc) do
+    case Regex.run(@failure_location_regex, line) do
+      [_line, file, number] ->
+        %{acc | state: %{failure | file: file, line: String.to_integer(number)}}
+
+      nil ->
+        %{acc | state: :scanning}
+    end
+  end
+
+  defp failure_line(line, %{state: failure} = acc) when is_map(failure) do
+    cond do
+      Regex.match?(@failure_detail_regex, line) ->
+        close_failure(%{acc | state: %{failure | raw: [line | failure.raw]}})
+
+      String.trim(line) == "" ->
+        close_failure(acc)
+
+      true ->
+        message = [String.trim(line) | failure.message]
+        %{acc | state: %{failure | message: message, raw: [line | failure.raw]}}
+    end
+  end
+
+  # A block with no location never became a failure, so there is nothing to
+  # close; the reduce just returns to scanning.
+  defp close_failure(%{state: :scanning} = acc), do: acc
+
+  defp close_failure(%{state: %{file: nil}} = acc), do: %{acc | state: :scanning}
+
+  defp close_failure(%{state: failure} = acc) do
+    %{acc | state: :scanning, failures: [failure | acc.failures]}
+  end
+
+  defp failure_finding(failure, apps) do
+    file = Finding.relative_path(failure.file)
+
+    %Finding{
+      file: file,
+      line: failure.line,
+      app: Umbrella.app_for_path(file, apps),
+      severity: :error,
+      check: failure.module,
+      message: describe_failure(failure),
+      raw: failure.raw |> Enum.reverse() |> Enum.join("\n")
+    }
+  end
+
+  defp describe_failure(%{name: name, message: []}), do: name
+
+  defp describe_failure(%{name: name, message: message}) do
+    "#{name}: #{message |> Enum.reverse() |> Enum.join(" ")}"
   end
 
   defp merge_test_counts(stats, []), do: stats

--- a/lib/mix/tasks/quality.ex
+++ b/lib/mix/tasks/quality.ex
@@ -268,19 +268,28 @@ defmodule Mix.Tasks.Quality do
       # reader knows what this run is not evidence for.
       Enum.each(skipped, &Printer.print_result/1)
 
-      tasks =
-        Enum.map(stages, fn {_stage, module, _name} ->
-          Task.async(fn ->
-            result = module.run(config)
-            Printer.print_result(result)
-            result
-          end)
+      {writers, readers} =
+        Enum.split_with(stages, fn {_stage, module, _name} ->
+          Stage.kind(module, config) == :writer
         end)
 
-      skipped ++ Enum.map(tasks, &Task.await(&1, :infinity))
+      # Writers go first, one at a time. A stage that recompiles the project
+      # rewrites the beams the readers are part-way through, and the reader
+      # that notices reports a failure about the build rather than the code.
+      writer_results = Enum.map(writers, &run_stage(&1, config))
+
+      tasks = Enum.map(readers, fn stage -> Task.async(fn -> run_stage(stage, config) end) end)
+
+      skipped ++ writer_results ++ Enum.map(tasks, &Task.await(&1, :infinity))
     after
       Printer.stop()
     end
+  end
+
+  defp run_stage({_stage, module, _name}, config) do
+    result = module.run(config)
+    Printer.print_result(result)
+    result
   end
 
   # Every optional stage is either run or reported as skipped with its reason.

--- a/test/ex_quality/aliases_test.exs
+++ b/test/ex_quality/aliases_test.exs
@@ -1,0 +1,119 @@
+defmodule ExQuality.AliasesTest do
+  # Not async: each test swaps the project Mix reads its aliases from.
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias ExQuality.Aliases
+  alias ExQuality.Stage
+
+  doctest ExQuality.Aliases
+
+  defmodule AliasedProject do
+    @moduledoc false
+    def project do
+      [
+        app: :aliased,
+        aliases: [
+          sobelow: ["cmd --app web mix sobelow --config"],
+          "test.coverage": ["test --cover --export-coverage default", "test.coverage"],
+          test: ["ecto.create --quiet", "ecto.migrate", "test"]
+        ]
+      ]
+    end
+  end
+
+  # Pushes a project whose mix.exs defines the aliases above, so the stages see
+  # what they would see in a real project that shadows their tasks.
+  defp with_aliases(fun) do
+    Mix.Project.push(AliasedProject, "mix.exs")
+
+    try do
+      fun.()
+    after
+      Mix.Project.pop()
+    end
+  end
+
+  describe "shadowing?/1" do
+    test "finds an alias with the task's name" do
+      with_aliases(fn ->
+        assert Aliases.shadowing?("sobelow")
+        assert Aliases.shadowing?("test.coverage")
+      end)
+    end
+
+    test "does not report a task the project left alone" do
+      with_aliases(fn ->
+        refute Aliases.shadowing?("credo")
+        refute Aliases.shadowing?("dialyzer")
+      end)
+    end
+
+    test "takes an atom as well as a string" do
+      with_aliases(fn ->
+        assert Aliases.shadowing?(:sobelow)
+      end)
+    end
+  end
+
+  describe "shadowed/2" do
+    test "names the alias and what to do about it" do
+      result = Aliases.shadowed("Sobelow", "sobelow")
+
+      assert result.status == :error
+      assert result.summary == "mix sobelow is aliased in mix.exs"
+      assert result.output =~ "defines a Mix alias named `sobelow`"
+      assert result.output =~ "sobelow.all"
+      assert Stage.findings(result) == []
+    end
+  end
+
+  describe "stages refuse to run a task the project has aliased" do
+    test "Sobelow says so instead of reporting a missing report" do
+      with_aliases(fn ->
+        System |> reject(:cmd, 3)
+
+        result = ExQuality.Stages.Sobelow.run([])
+
+        assert result.status == :error
+        assert result.summary == "mix sobelow is aliased in mix.exs"
+      end)
+    end
+
+    test "Tests says so rather than aggregating a suite it ran twice" do
+      with_aliases(fn ->
+        stub(ExQuality.Umbrella, :umbrella?, fn -> true end)
+        stub(ExQuality.Tools, :available?, fn tool -> tool == :native_coverage end)
+        System |> reject(:cmd, 3)
+
+        result = ExQuality.Stages.Test.run(test: [coverage: true])
+
+        assert result.status == :error
+        assert result.summary == "mix test.coverage is aliased in mix.exs"
+      end)
+    end
+
+    test "an aliased mix test is left alone, because running it is correct" do
+      with_aliases(fn ->
+        stub(ExQuality.Tools, :available?, fn _tool -> false end)
+
+        System
+        |> expect(:cmd, fn "mix", ["test"], _opts -> {"1 tests, 0 failures\n", 0} end)
+
+        result = ExQuality.Stages.Test.run([])
+
+        assert result.status == :ok
+        assert result.stats.test_count == 1
+      end)
+    end
+
+    test "Credo runs when the project has not aliased it" do
+      with_aliases(fn ->
+        System
+        |> expect(:cmd, fn "mix", ["credo" | _rest], _opts -> {~s({"issues": []}), 0} end)
+
+        assert ExQuality.Stages.Credo.run([]).status == :ok
+      end)
+    end
+  end
+end

--- a/test/ex_quality/aliases_test.exs
+++ b/test/ex_quality/aliases_test.exs
@@ -5,6 +5,7 @@ defmodule ExQuality.AliasesTest do
 
   alias ExQuality.Aliases
   alias ExQuality.Stage
+  alias ExQuality.Stages
 
   doctest ExQuality.Aliases
 
@@ -73,7 +74,7 @@ defmodule ExQuality.AliasesTest do
       with_aliases(fn ->
         System |> reject(:cmd, 3)
 
-        result = ExQuality.Stages.Sobelow.run([])
+        result = Stages.Sobelow.run([])
 
         assert result.status == :error
         assert result.summary == "mix sobelow is aliased in mix.exs"
@@ -86,7 +87,7 @@ defmodule ExQuality.AliasesTest do
         stub(ExQuality.Tools, :available?, fn tool -> tool == :native_coverage end)
         System |> reject(:cmd, 3)
 
-        result = ExQuality.Stages.Test.run(test: [coverage: true])
+        result = Stages.Test.run(test: [coverage: true])
 
         assert result.status == :error
         assert result.summary == "mix test.coverage is aliased in mix.exs"
@@ -100,7 +101,7 @@ defmodule ExQuality.AliasesTest do
         System
         |> expect(:cmd, fn "mix", ["test"], _opts -> {"1 tests, 0 failures\n", 0} end)
 
-        result = ExQuality.Stages.Test.run([])
+        result = Stages.Test.run([])
 
         assert result.status == :ok
         assert result.stats.test_count == 1
@@ -112,7 +113,7 @@ defmodule ExQuality.AliasesTest do
         System
         |> expect(:cmd, fn "mix", ["credo" | _rest], _opts -> {~s({"issues": []}), 0} end)
 
-        assert ExQuality.Stages.Credo.run([]).status == :ok
+        assert Stages.Credo.run([]).status == :ok
       end)
     end
   end

--- a/test/ex_quality/stages/dialyzer_test.exs
+++ b/test/ex_quality/stages/dialyzer_test.exs
@@ -261,7 +261,8 @@ defmodule ExQuality.Stages.DialyzerTest do
 
   # Runs `fun` from a tree that is an umbrella containing exactly these files.
   defp in_project(files, fun) do
-    root = Path.join(System.tmp_dir!(), "ex_quality-dialyzer-#{System.unique_integer([:positive])}")
+    root =
+      Path.join(System.tmp_dir!(), "ex_quality-dialyzer-#{System.unique_integer([:positive])}")
 
     Enum.each(files, fn path ->
       full = Path.join(root, path)

--- a/test/ex_quality/stages/dialyzer_test.exs
+++ b/test/ex_quality/stages/dialyzer_test.exs
@@ -1,5 +1,7 @@
 defmodule ExQuality.Stages.DialyzerTest do
-  use ExUnit.Case, async: true
+  # Not async: attributing an app-relative path to an app is done by looking
+  # for the file, so those tests run from a tree of their own.
+  use ExUnit.Case, async: false
   use Mimic
 
   import ExUnit.CaptureIO
@@ -209,6 +211,77 @@ defmodule ExQuality.Stages.DialyzerTest do
     end
   end
 
+  describe "run/1 - umbrella paths relative to a child app" do
+    # dialyxir running once from an umbrella root prints each path relative to
+    # the app it found the file in, with no header saying which app that was.
+    setup do
+      stub_dialyzer(
+        """
+        lib/core/integrations.ex:65:29:unknown_type Unknown type: Core.User.t/0.
+        lib/application.ex:1:no_return Function start/2 has no local return.
+        lib/nowhere.ex:3:unknown_type Unknown type: Gone.t/0.
+        """,
+        1
+      )
+
+      :ok
+    end
+
+    test "resolves the path against the app that has the file, and names it" do
+      files = ["apps/core/lib/core/integrations.ex", "apps/web/lib/application.ex"]
+
+      in_project(files, fn ->
+        assert [integrations, application, nowhere] = ExQuality.Stage.findings(Dialyzer.run([]))
+
+        assert integrations.app == :core
+        assert integrations.file == "apps/core/lib/core/integrations.ex"
+
+        assert application.app == :web
+        assert application.file == "apps/web/lib/application.ex"
+
+        # No app has it, so nothing is invented: the path is left as dialyxir
+        # reported it.
+        assert nowhere.app == nil
+        assert nowhere.file == "lib/nowhere.ex"
+      end)
+    end
+
+    test "does not guess when two apps have the same relative path" do
+      files = ["apps/core/lib/application.ex", "apps/web/lib/application.ex"]
+
+      in_project(files, fn ->
+        findings = ExQuality.Stage.findings(Dialyzer.run([]))
+        application = Enum.find(findings, &(&1.file =~ "application.ex"))
+
+        assert application.app == nil
+        assert application.file == "lib/application.ex"
+      end)
+    end
+  end
+
+  # Runs `fun` from a tree that is an umbrella containing exactly these files.
+  defp in_project(files, fun) do
+    root = Path.join(System.tmp_dir!(), "ex_quality-dialyzer-#{System.unique_integer([:positive])}")
+
+    Enum.each(files, fn path ->
+      full = Path.join(root, path)
+      File.mkdir_p!(Path.dirname(full))
+      File.write!(full, "")
+    end)
+
+    stub(ExQuality.Umbrella, :apps_paths, fn -> %{core: "apps/core", web: "apps/web"} end)
+
+    File.mkdir_p!(root)
+    cwd = File.cwd!()
+
+    try do
+      File.cd!(root, fun)
+    after
+      File.cd!(cwd)
+      File.rm_rf!(root)
+    end
+  end
+
   describe "run/1 - single warning" do
     setup do
       stub_dialyzer(
@@ -254,6 +327,36 @@ defmodule ExQuality.Stages.DialyzerTest do
       assert result.status == :ok
       assert result.stats.warning_count == 0
       assert result.summary == "No warnings (some files skipped)"
+    end
+  end
+
+  describe "run/1 - analysis that never ran" do
+    setup do
+      # What dialyxir prints when the beams are rewritten under it: the same
+      # debug_info error as a genuine skip, but no tally, because it stopped
+      # before it had one.
+      stub_dialyzer(
+        """
+        Finding suitable PLTs
+        Proceeding with analysis...
+        Could not get Core Erlang code for: /path/to/build/dev/lib/web/ebin/Elixir.Web.beam
+        Recompile with +debug_info or analyze the .erl file instead
+        """,
+        1
+      )
+
+      :ok
+    end
+
+    test "fails rather than passing on an analysis that produced no tally" do
+      result = Dialyzer.run([])
+
+      assert result.status == :error
+      assert result.summary == "Analysis did not complete (build changed under it? see output)"
+    end
+
+    test "carries the tool's output verbatim" do
+      assert Dialyzer.run([]).output =~ "Could not get Core Erlang code"
     end
   end
 

--- a/test/ex_quality/stages/gettext_test.exs
+++ b/test/ex_quality/stages/gettext_test.exs
@@ -1,124 +1,268 @@
 defmodule ExQuality.Stages.GettextTest do
-  use ExUnit.Case, async: true
+  # Not async: the stage reads `.po` files relative to the working directory,
+  # so each test runs from a tree of its own.
+  use ExUnit.Case, async: false
   use Mimic
 
+  alias ExQuality.Stage
   alias ExQuality.Stages.Gettext
 
-  describe "run/1 - no translation issues" do
-    setup do
-      # Mock gettext.extract command
-      System
-      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts ->
-        {"Extracted gettext strings", 0}
-      end)
+  @untranslated """
+  msgid ""
+  msgstr ""
+  "Language: fr\\n"
 
-      # Mock find command - no .po files found or empty result
-      System
-      |> stub(:cmd, fn "find", _args, _opts ->
-        {"", 0}
-      end)
+  #: lib/web/page.ex:12
+  msgid "Hello"
+  msgstr ""
+  """
 
-      :ok
-    end
+  @translated """
+  msgid ""
+  msgstr ""
+  "Language: fr\\n"
 
-    test "returns success when no translation files found" do
-      result = Gettext.run([])
+  #: lib/web/page.ex:12
+  msgid "Hello"
+  msgstr "Bonjour"
+  """
 
-      assert result.name == "Gettext"
-      assert result.status == :ok
-      assert result.summary == "All translations complete"
-      assert is_integer(result.duration_ms)
-      assert result.duration_ms >= 0
-    end
-  end
+  @fuzzy """
+  msgid ""
+  msgstr ""
+  "Language: fr\\n"
 
-  describe "run/1 - extraction failed" do
-    setup do
-      # Mock gettext.extract command - failure
-      System
-      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts ->
-        {"Extraction failed: gettext not configured", 1}
-      end)
+  #, fuzzy
+  msgid "Goodbye"
+  msgstr "Au revoir"
+  """
 
-      :ok
-    end
+  # Each test describes the tree it wants as `path => contents` and is run from
+  # inside it, because the stage's whole job is finding files from the root.
+  defp in_project(files, fun) do
+    root = Path.join(System.tmp_dir!(), "ex_quality-gettext-#{System.unique_integer([:positive])}")
 
-    test "returns error when extraction fails" do
-      result = Gettext.run([])
+    Enum.each(files, fn {path, contents} ->
+      full = Path.join(root, path)
+      File.mkdir_p!(Path.dirname(full))
+      File.write!(full, contents)
+    end)
 
-      assert result.status == :error
-      assert result.summary == "Extraction failed"
-    end
-  end
+    File.mkdir_p!(root)
+    cwd = File.cwd!()
 
-  describe "run/1 - missing translations" do
-    setup do
-      # Mock gettext.extract command
-      System
-      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts ->
-        {"Extracted gettext strings", 0}
-      end)
-
-      # This test is simplified since gettext stage implementation uses File operations
-      # For full mocking, we'd need to mock File.read! and File.exists? as well
-      # For now, just verify the stage doesn't crash
-      :ok
-    end
-
-    test "handles translation checking gracefully" do
-      result = Gettext.run([])
-
-      assert is_map(result)
-      assert result.name == "Gettext"
-      assert result.status in [:ok, :error]
+    try do
+      File.cd!(root, fun)
+    after
+      File.cd!(cwd)
+      File.rm_rf!(root)
     end
   end
 
-  describe "run/1 - timing" do
-    setup do
-      System
-      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts ->
-        Process.sleep(10)
-        {"Extracted", 0}
-      end)
-      |> stub(:cmd, fn "find", _args, _opts ->
-        {"", 0}
-      end)
+  defp stub_umbrella(apps) do
+    stub(ExQuality.Umbrella, :apps_paths, fn -> apps end)
+  end
 
+  describe "stage_kind/1" do
+    test "reads by default" do
+      assert Gettext.stage_kind([]) == :reader
+    end
+
+    test "writes when configured to extract" do
+      assert Gettext.stage_kind(gettext: [extract: true]) == :writer
+    end
+  end
+
+  describe "run/1 - umbrella" do
+    setup do
+      stub_umbrella(%{core: "apps/core", web: "apps/web"})
       :ok
     end
 
-    test "records execution duration" do
-      result = Gettext.run([])
+    test "finds .po files under the child apps and names the app" do
+      files = %{
+        "apps/web/priv/gettext/fr/LC_MESSAGES/default.po" => @untranslated,
+        "apps/core/priv/gettext/fr/LC_MESSAGES/default.po" => @translated
+      }
 
-      assert result.duration_ms >= 10
-      assert result.duration_ms < 5_000
+      in_project(files, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :error
+        assert [finding] = Stage.findings(result)
+        assert finding.app == :web
+        assert finding.file == "apps/web/priv/gettext/fr/LC_MESSAGES/default.po"
+        assert finding.line == 6
+        assert finding.check == "missing"
+        assert finding.message == ~s(missing translation for "Hello")
+      end)
+    end
+
+    test "counts every app's files, not just the first" do
+      files = %{
+        "apps/web/priv/gettext/fr/LC_MESSAGES/default.po" => @translated,
+        "apps/core/priv/gettext/fr/LC_MESSAGES/default.po" => @translated
+      }
+
+      in_project(files, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :ok
+        assert result.stats.file_count == 2
+        assert result.summary == "All translations complete (2 files)"
+      end)
+    end
+  end
+
+  describe "run/1 - nothing to read" do
+    setup do
+      stub_umbrella(%{})
+      :ok
+    end
+
+    test "skips rather than passes when there are no .po files at all" do
+      in_project(%{"mix.exs" => ""}, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :skipped
+        assert result.summary == "no .po files found"
+      end)
+    end
+
+    test "skips when the only locale is the source locale" do
+      in_project(%{"priv/gettext/en/LC_MESSAGES/default.po" => @untranslated}, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :skipped
+        assert result.summary == "no .po files outside the source locale"
+      end)
+    end
+
+    test "skips when every file was excluded by name" do
+      in_project(%{"priv/gettext/fr/LC_MESSAGES/errors.po" => @untranslated}, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :skipped
+        assert result.summary == "no .po files outside the source locale"
+      end)
     end
   end
 
   describe "run/1 - configuration" do
     setup do
-      System
-      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts ->
-        {"Extracted", 0}
-      end)
-      |> stub(:cmd, fn "find", _args, _opts ->
-        {"", 0}
-      end)
-
+      stub_umbrella(%{})
       :ok
     end
 
-    test "handles empty config" do
-      result = Gettext.run([])
+    test "the source locale is configurable" do
+      files = %{
+        "priv/gettext/en/LC_MESSAGES/default.po" => @untranslated,
+        "priv/gettext/fr/LC_MESSAGES/default.po" => @translated
+      }
 
-      assert result.status == :ok
+      in_project(files, fn ->
+        result = Gettext.run(gettext: [source_locale: "fr"])
+
+        assert result.status == :error
+        assert [%{file: "priv/gettext/en/LC_MESSAGES/default.po"}] = Stage.findings(result)
+      end)
     end
 
-    test "ignores config options" do
-      result = Gettext.run(some_option: true)
+    test "the excluded basenames are configurable" do
+      in_project(%{"priv/gettext/fr/LC_MESSAGES/errors.po" => @untranslated}, fn ->
+        result = Gettext.run(gettext: [exclude: []])
 
-      assert result.status == :ok
+        assert result.status == :error
+        assert [%{check: "missing"}] = Stage.findings(result)
+      end)
     end
+  end
+
+  describe "run/1 - fuzzy translations" do
+    setup do
+      stub_umbrella(%{})
+      :ok
+    end
+
+    test "reports a fuzzy entry at its msgid" do
+      in_project(%{"priv/gettext/fr/LC_MESSAGES/default.po" => @fuzzy}, fn ->
+        result = Gettext.run([])
+
+        assert result.status == :error
+        assert [finding] = Stage.findings(result)
+        assert finding.check == "fuzzy"
+        assert finding.line == 6
+        assert result.summary == "1 fuzzy translation"
+      end)
+    end
+  end
+
+  describe "run/1 - extraction" do
+    setup do
+      stub_umbrella(%{})
+      :ok
+    end
+
+    test "does not run extraction, or write anything, by default" do
+      System
+      |> reject(:cmd, 3)
+
+      files = %{"priv/gettext/fr/LC_MESSAGES/default.po" => @translated}
+
+      in_project(files, fn ->
+        before = snapshot()
+        assert Gettext.run([]).status == :ok
+        assert snapshot() == before
+      end)
+    end
+
+    test "runs extraction when asked" do
+      System
+      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts -> {"Extracted", 0} end)
+
+      files = %{"priv/gettext/fr/LC_MESSAGES/default.po" => @translated}
+
+      in_project(files, fn ->
+        assert Gettext.run(gettext: [extract: true]).status == :ok
+      end)
+    end
+
+    test "fails when extraction fails" do
+      System
+      |> expect(:cmd, fn "mix", ["gettext.extract", "--merge"], _opts -> {"boom", 1} end)
+
+      in_project(%{}, fn ->
+        result = Gettext.run(gettext: [extract: true])
+
+        assert result.status == :error
+        assert result.summary == "Extraction failed"
+      end)
+    end
+  end
+
+  describe "run/1 - timing" do
+    setup do
+      stub_umbrella(%{})
+      :ok
+    end
+
+    test "records execution duration" do
+      in_project(%{"priv/gettext/fr/LC_MESSAGES/default.po" => @translated}, fn ->
+        result = Gettext.run([])
+
+        assert is_integer(result.duration_ms)
+        assert result.duration_ms >= 0
+        assert result.duration_ms < 5_000
+      end)
+    end
+  end
+
+  # Every file's path and mtime: what a check that must not touch the tree is
+  # measured against.
+  defp snapshot do
+    "**/*"
+    |> Path.wildcard(match_dot: true)
+    |> Enum.map(&{&1, File.stat!(&1).mtime})
+    |> Enum.sort()
   end
 end

--- a/test/ex_quality/stages/gettext_test.exs
+++ b/test/ex_quality/stages/gettext_test.exs
@@ -40,7 +40,8 @@ defmodule ExQuality.Stages.GettextTest do
   # Each test describes the tree it wants as `path => contents` and is run from
   # inside it, because the stage's whole job is finding files from the root.
   defp in_project(files, fun) do
-    root = Path.join(System.tmp_dir!(), "ex_quality-gettext-#{System.unique_integer([:positive])}")
+    root =
+      Path.join(System.tmp_dir!(), "ex_quality-gettext-#{System.unique_integer([:positive])}")
 
     Enum.each(files, fn {path, contents} ->
       full = Path.join(root, path)

--- a/test/ex_quality/stages/test_test.exs
+++ b/test/ex_quality/stages/test_test.exs
@@ -132,6 +132,112 @@ defmodule ExQuality.Stages.TestTest do
       assert result.summary == "3 of 124 failed"
       assert result.output =~ "test/my_app_test.exs:42"
     end
+
+    test "parses each failure into a finding a caller can route" do
+      assert [first, second, third] = ExQuality.Stage.findings(Test.run([]))
+
+      assert %ExQuality.Finding{
+               file: "test/my_app_test.exs",
+               line: 42,
+               severity: :error,
+               check: "MyAppTest",
+               message: "handles error case: Expected true, got false"
+             } = first
+
+      assert %{line: 55, message: "validates input: Assertion failed"} = second
+      assert %{line: 68, message: "processes data: Expected 5, got 4"} = third
+    end
+  end
+
+  describe "run/1 - failures in an umbrella" do
+    setup do
+      ExQuality.Tools
+      |> stub(:available?, fn _tool -> false end)
+
+      ExQuality.Umbrella
+      |> stub(:apps_paths, fn -> %{walt_ui: "apps/walt_ui"} end)
+
+      System
+      |> expect(:cmd, fn "mix", ["test"], _opts ->
+        output = """
+        ==> walt_ui
+        .....F
+
+          1) test Oban jobs a job execution produces a consumer span (WaltUi.Telemetry.ConsumerTracingTest)
+             apps/walt_ui/test/walt_ui/telemetry/consumer_tracing_test.exs:118
+             expected an Oban job span named 'process default'
+             code: assert job_span, "expected an Oban job span named 'process default'"
+             stacktrace:
+               test/walt_ui/telemetry/consumer_tracing_test.exs:145: (test)
+
+
+        Finished in 3.1 seconds
+        6 tests, 1 failure
+        """
+
+        {output, 1}
+      end)
+
+      :ok
+    end
+
+    test "attributes the failure to its app, from the header line's path" do
+      assert [finding] = ExQuality.Stage.findings(Test.run([]))
+
+      assert finding.app == :walt_ui
+      assert finding.file == "apps/walt_ui/test/walt_ui/telemetry/consumer_tracing_test.exs"
+      assert finding.line == 118
+      assert finding.check == "WaltUi.Telemetry.ConsumerTracingTest"
+    end
+
+    test "reads the header line rather than the app-relative stacktrace" do
+      [finding] = ExQuality.Stage.findings(Test.run([]))
+
+      # The stacktrace says test/... and line 145; only the header line opens
+      # from the umbrella root.
+      refute finding.file == "test/walt_ui/telemetry/consumer_tracing_test.exs"
+      refute finding.line == 145
+    end
+
+    test "keeps the failure's own lines on the finding" do
+      [finding] = ExQuality.Stage.findings(Test.run([]))
+
+      assert finding.raw =~ "1) test Oban jobs"
+      assert finding.raw =~ "expected an Oban job span"
+    end
+  end
+
+  describe "run/1 - failures the parser does not recognise" do
+    setup do
+      ExQuality.Tools
+      |> stub(:available?, fn _tool -> false end)
+
+      # Two failures reported, one of them in a shape the parser cannot read.
+      System
+      |> expect(:cmd, fn "mix", ["test"], _opts ->
+        output = """
+          1) test handles error case (MyAppTest)
+             test/my_app_test.exs:42
+             Expected true, got false
+
+        ** (exit) an unparseable catastrophe
+
+        2 tests, 2 failures
+        """
+
+        {output, 1}
+      end)
+
+      :ok
+    end
+
+    test "reports nothing rather than a partial list that reads as complete" do
+      result = Test.run([])
+
+      assert ExQuality.Stage.findings(result) == []
+      assert result.output =~ "an unparseable catastrophe"
+      assert result.output =~ "1) test handles error case"
+    end
   end
 
   describe "run/1 - coverage below threshold" do

--- a/test/mix/tasks/quality_test.exs
+++ b/test/mix/tasks/quality_test.exs
@@ -242,6 +242,108 @@ defmodule Mix.Tasks.QualityTest do
     end
   end
 
+  describe "stages that write to the build are kept out of the parallel set" do
+    setup do
+      ExQuality.Tools
+      |> stub(:detect, fn ->
+        %{
+          credo: true,
+          dialyzer: true,
+          doctor: false,
+          gettext: true,
+          coverage: false,
+          audit: false,
+          sobelow: false
+        }
+      end)
+      |> stub(:available?, fn tool -> tool in [:credo, :dialyzer, :gettext] end)
+
+      :ok
+    end
+
+    test "the writer finishes before any reader starts" do
+      # Gettext's extraction recompiles the project, so a dialyzer reading the
+      # same build while it happens sees the beams change underneath it and
+      # reports an analysis that never ran.
+      ExQuality.Config
+      |> stub(:load, fn _opts -> [gettext: [extract: true], sobelow: [enabled: false]] end)
+
+      test_pid = self()
+
+      System
+      |> stub(:cmd, fn
+        "mix", ["gettext.extract", "--merge"], _opts ->
+          send(test_pid, {:cmd, :gettext_started})
+          Process.sleep(50)
+          send(test_pid, {:cmd, :gettext_finished})
+          {"", 0}
+
+        "mix", ["dialyzer" | _], opts ->
+          send(test_pid, {:cmd, :dialyzer_started})
+          _collected = Enum.into(["Total errors: 0"], opts[:into])
+          {opts[:into], 0}
+
+        "mix", ["credo" | _], _opts ->
+          send(test_pid, {:cmd, :credo_started})
+          {"", 0}
+
+        "mix", ["test" | _], _opts ->
+          send(test_pid, {:cmd, :test_started})
+          {"1 tests, 0 failures\n", 0}
+
+        _cmd, _args, _opts ->
+          {"", 0}
+      end)
+
+      capture_io(fn -> Quality.run([]) end)
+
+      events = drain_events()
+
+      assert :dialyzer_started in events
+      assert :credo_started in events
+
+      # Nothing else had started by the time the writer was done.
+      assert Enum.take_while(events, &(&1 != :gettext_finished)) == [:gettext_started]
+    end
+
+    test "a gettext that only reads stays in the parallel set" do
+      ExQuality.Config
+      |> stub(:load, fn _opts -> [sobelow: [enabled: false]] end)
+
+      test_pid = self()
+
+      System
+      |> stub(:cmd, fn
+        "mix", ["gettext.extract" | _], _opts ->
+          send(test_pid, {:cmd, :extracted})
+          {"", 0}
+
+        "mix", ["dialyzer" | _], opts ->
+          _collected = Enum.into(["Total errors: 0"], opts[:into])
+          {opts[:into], 0}
+
+        "mix", ["test" | _], _opts ->
+          {"1 tests, 0 failures\n", 0}
+
+        _cmd, _args, _opts ->
+          {"", 0}
+      end)
+
+      capture_io(fn -> Quality.run([]) end)
+
+      refute_received {:cmd, :extracted}
+    end
+
+    # The stage events in the order they happened.
+    defp drain_events(acc \\ []) do
+      receive do
+        {:cmd, event} -> drain_events([event | acc])
+      after
+        0 -> Enum.reverse(acc)
+      end
+    end
+  end
+
   describe "failure output uses findings when a stage supplies them" do
     test "renders credo issues grouped by file instead of raw tool output" do
       issues = [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 # Configure Mimic for mocking System.cmd/3 in unit tests
 Mimic.copy(System)
+Mimic.copy(ExQuality.Config)
 Mimic.copy(ExQuality.Tools)
 Mimic.copy(ExQuality.Umbrella)
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -74,11 +74,27 @@ underlying tool to get detail that is already on screen.
 | Dependencies | an unused dep, or an advisory with the version that fixes it | `mix deps.unlock <pkg>` for unused; upgrading to the patched version for an advisory |
 | Doctor | documentation coverage below the project's threshold | writing the missing `@moduledoc`/`@doc` |
 | Gettext | missing or fuzzy translations | translating them, or resolving the fuzzy entries |
+| any stage | `mix <task> is aliased in mix.exs` | renaming the alias, see below |
 | Sobelow | a security finding at or above the blocking threshold | fixing it at `file:line` |
 | Tests | a test failure, or modules under the coverage threshold | fixing the code, or writing tests for the named modules |
 
 Coverage failures name the modules that are under the threshold. Write tests
 for those modules. Do not test unrelated code to raise the average.
+
+## Mix aliases
+
+ExQuality shells out to the real `mix credo`, `mix dialyzer`, `mix format`,
+`mix sobelow`, `mix deps.unlock` and `mix test.coverage`. Mix resolves aliases
+before tasks, so a `mix.exs` alias with one of those names changes what is
+measured, silently.
+
+Do not add an alias with one of those names. If the project already has one,
+the stage says so and refuses to run; rename the alias (`sobelow.all` is the
+usual choice) and update the scripts that call it.
+
+`test` is the exception. An alias like
+`test: ["ecto.create --quiet", "ecto.migrate", "test"]` is correct and
+supported: it does the setup the suite needs.
 
 ## Never do these
 


### PR DESCRIPTION
Correctness fixes found by adopting ex_quality 0.7.0 on a 10-app Elixir/Phoenix umbrella. Each was reproduced on that project before being fixed here.

The headline one is a silent false pass: `mix quality` reported `✓ Dialyzer: No warnings` on a project with 110 real dialyzer warnings.

## The false pass

Gettext extraction compiles the project and rewrites `.po`/`.pot` files while the analysis stages read the same build. Dialyzer, reading it with `--no-compile`, hit `Could not get Core Erlang code` and reported nothing, which the `debug_info` escape hatch promoted to a pass.

Fixed in three places, so no single one has to hold:

- Stages declare `stage_kind/1`. Writers run serialized before the parallel readers, the way compilation already does.
- Dialyzer distinguishes "ran and found nothing" from "never ran" by whether dialyxir printed its own tally, and fails the second case rather than passing it.
- Gettext no longer extracts by default, so it no longer writes to the repo or the build. `gettext: [extract: true]` opts back in.

## Gettext scanned nothing and passed

`find priv/gettext` from an umbrella root finds nothing (translations live in `apps/*/priv/gettext`), and the `/en/` and `errors.po` filters rejected the rest. The stage reported `All translations complete` having read no files.

It now finds `.po` files by wildcard over the umbrella's apps plus the root, emits `%ExQuality.Finding{}` with app attribution instead of prose, makes the source locale configurable, and reports `:skipped` with a reason rather than `:ok` when it read nothing.

It also no longer mutates the working tree: a run used to modify two `.pot` files and create six untracked ones, and leave the dev build in a state where `mix compile --warnings-as-errors` failed until `mix compile --force`.

## Mix aliases silently shadow the tasks stages shell out to

Mix resolves aliases before tasks, so a project that defines a `sobelow` or `test.coverage` alias silently changes what the stage measures. On the adopting project, sobelow never wrote its JSON report, and `test.coverage` ran the whole 3702-test suite a second time before aggregating (`test_count: 7404`, stage time 109s vs 45-63s). Neither said why.

`ExQuality.Aliases.shadowing?/1` reads the project's aliases, and the stages whose parsing depends on their exact invocation return an error naming the alias instead of shelling out. `mix test` is the deliberate exception: a `test:` alias does the setup the suite needs, and running it is correct. That case is pinned by a test.

## Routing

- **Dialyzer app attribution.** All 110 warnings came back with `app: null` and app-relative paths that do not open from the umbrella root. Paths are now resolved against the app that has the file; an ambiguous match is left alone rather than guessed at.
- **ExUnit failures parse into findings.** A failing suite came back with no findings and ~30 KB of run log with the one failure buried in it. Failure blocks now parse into findings with file, line, app, test module and assertion message, read from the header line rather than the app-relative stacktrace. The parse is used only when it accounts for every failure the suite counted, so a short parse falls back to the full output instead of reading as a complete list.

## Docs

`docs/umbrella.md` described Tests, Coverage and Sobelow as umbrella-aware and said nothing about Gettext or Dialyzer, which were the two that were not. Both are now covered, along with the alias constraint. `usage-rules.md` states the alias constraint too, since that is the file an agent reads before touching a project's `mix.exs`.
