### PR TITLE
Adds multi-config Credo and custom stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Credo can run more than one config.** A `.credo.exs` that declares a second config - the usual case is one check over `priv/*/migrations/`, which sits outside credo's default `files.included` - had that config silently never run, because the stage always invoked `mix credo` once with no `--config-name`. A check the project believes is enforced, was not. `credo: [configs: ["default", "migrations"]]` now runs one invocation per name, in order, and merges the results into one stage result
+- Findings from multiple credo configs are deduplicated on `{file, line, column, check}`, so two configs with overlapping `files` globs do not double an issue count
+- A credo run that fails without reporting issues now names the config it came from (`Check failed in "migrations" (see output)`), because the likeliest cause is a config name `.credo.exs` does not define
+- **Custom stages.** A project with a house check, a schema linter, a custom mix task or a shell script gate could have ExQuality's parallelism, timing, report and printer, or it could have its own check, but not both - so those checks lived outside the run, outside the JSON report, and outside anything that routes findings to fixers. `custom:` in `.quality.exs` registers them as stages. An entry names either a `module:` implementing the existing `ExQuality.Stage` contract, or a `command:` run by the new `ExQuality.Stages.Command`
+- A custom command reports structured findings by printing one JSON document on stdout (`summary`, `stats`, `findings`); only `file` and `message` are required per finding, and `app` is inferred from the path. Output that does not parse falls through verbatim, as everywhere else. `parse: :none` opts out for a command known to print prose
+- `skip_exit_code:` lets a custom command say "not applicable" - a nullability check needs a migrated test database, and without it the stage fails with a database error that reads like a code problem. The stage reports `:skipped` with the command's own reason instead
+- `--skip <key>` skips any stage by key, built-in or custom, and is repeatable. `@switches` is static, so a custom stage could never have a `--skip-<key>` generated for it. The existing `--skip-credo` and friends are unchanged
+- `ExQuality.Finding.from_map/2`, the reading half of the report's finding encoding. It is what a custom command's output is decoded with, and what a consumer of a report needs in order to read one back
+
+### Changed
+
+- Malformed `custom:` entries fail the run at load time and name the offending entry: a missing `key` or `name`, neither or both of `module`/`command`, a key or name colliding with a built-in stage, a duplicate key, an unknown `kind`, or a module that is not loadable or does not export `run/1`. A stage that never registers is a check nobody is told is not running
+
 ## [0.8.0] - 2026-08-01
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ mix quality --skip-doctor         # skip documentation coverage
 mix quality --skip-gettext        # skip translation checks
 mix quality --skip-sobelow        # skip security analysis
 mix quality --skip-dependencies   # skip unused deps and the security audit
+mix quality --skip KEY            # skip any stage by key; repeatable
 mix quality --verbose             # print full output even for stages that passed
 mix quality --report PATH         # also write a JSON report to PATH
 mix quality --format json         # JSON report on stdout, human output on stderr
@@ -37,6 +38,19 @@ A skipped stage is still reported, with the flag as its reason:
 
 ```
 ○ Credo: skipped (--skip-credo)
+```
+
+`--skip KEY` takes a stage key rather than being one switch per stage, so it
+also reaches a custom stage, which has no `--skip-<key>` of its own. It is
+repeatable, and it names itself as the reason:
+
+```bash
+mix quality --skip nullability --skip credo
+```
+
+```
+○ Nullability: skipped (--skip nullability)
+○ Credo: skipped (--skip credo)
 ```
 
 ## `.quality.exs`
@@ -55,7 +69,10 @@ A keyword list at the project root. Every key is optional.
   credo: [
     enabled: :auto,
     strict: true,
-    all: false
+    all: false,
+    # Names of the .credo.exs configs to run, in order. nil is one run with no
+    # --config-name, which is credo's own default. See docs/stages.md.
+    configs: nil
   ],
 
   dialyzer: [
@@ -111,6 +128,83 @@ Every stage takes one of three values:
 | `:auto` | run when the tool is installed (the default) |
 | `true` | always run; errors if the tool is missing |
 | `false` | never run; reported as `○ Credo: skipped (disabled in .quality.exs)` |
+
+## Custom stages
+
+A project's own check - a house rule, a schema linter, a custom mix task, a
+shell script gate - runs as a stage of the run rather than beside it, declared
+under `custom:`. It then has the same parallelism, timing, printer and JSON
+report as a built-in stage, which is what lets a caller route its findings.
+
+```elixir
+custom: [
+  # A command. This is the case most projects want.
+  [
+    key: :nullability,
+    name: "Nullability",
+    command: "mix",
+    args: ["schema.nullability", "--format", "json"],
+    env: [{"MIX_ENV", "test"}],
+    kind: :reader
+  ],
+
+  # A module, for anything the command form cannot express.
+  [key: :house_rules, name: "House rules", module: MyApp.Quality.HouseRules]
+]
+```
+
+Every entry is a keyword list with `key` and `name`, plus either `module` or
+`command`. Registration lives in the entry rather than in callbacks on a module
+so the config file alone says what a run will contain: a stage that only
+announces itself once it has run cannot be reported as skipped.
+
+### Module entries
+
+`module:` names a module exporting `run/1` and returning an
+`ExQuality.Stage.result()` - the contract every built-in stage already
+satisfies. It may also export `stage_kind/1`; a module that does not is a
+reader.
+
+### Command entries
+
+| Key | Default | Meaning |
+|---|---|---|
+| `command`, `args` | required | passed to `System.cmd/3` |
+| `env` | `[]` | extra environment |
+| `cd` | project root | working directory |
+| `kind` | `:reader` | `:writer` runs it serialized, ahead of the readers |
+| `parse` | `:json` | `:json` attempts the finding contract, `:none` never tries |
+| `skip_exit_code` | none | exit code meaning "not applicable" |
+| `enabled` | `true` | `false` skips the stage, reported with the file as the reason |
+
+Exit code 0 is a pass, anything else is a failure. The command runs with
+`stderr_to_stdout: true`. The JSON finding contract, and the reader/writer
+warning, are in [stages.md](stages.md#custom-stages).
+
+### Validation
+
+A malformed entry fails the run at load time and names itself, because a stage
+that never registers is a check nobody is told is not running. The rules:
+
+- `key` and `name` are both required.
+- exactly one of `module` or `command`.
+- `key` and `name` may not collide with a built-in stage. A custom stage
+  shadowing Credo is the same class of bug as an aliased mix task.
+- `key` must be unique across entries.
+- `kind` must be `:reader` or `:writer`; `parse` must be `:json` or `:none`;
+  `skip_exit_code` must be an integer.
+- `module` must be loadable and export `run/1`.
+
+### What custom stages are not for
+
+Filling gaps in built-in stages. Routing a second `mix credo` config through a
+custom command would work and would be a mistake: the output comes back as text
+instead of per-check findings, and per-check routing is the reason the JSON
+report exists. If a built-in stage cannot express something its tool supports,
+that is a bug in the stage - `credo.configs` exists for exactly that reason.
+
+Nor are they a way to get out from under a failing check. Converting a stage
+into a custom one so it can be skipped moves the problem rather than fixing it.
 
 ## Test arguments
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -48,7 +48,7 @@ the two can never disagree.
 
 | Field | Type | Notes |
 |---|---|---|
-| `name` | string | `Format`, `Compile`, `Credo`, `Dialyzer`, `Dependencies`, `Doctor`, `Gettext`, `Sobelow`, `Tests` |
+| `name` | string | `Format`, `Compile`, `Credo`, `Dialyzer`, `Dependencies`, `Doctor`, `Gettext`, `Sobelow`, `Tests`, or a custom stage's own name |
 | `status` | `"ok"` \| `"error"` \| `"skipped"` | |
 | `summary` | string | the same one-line summary the console prints; for a skipped stage, the reason |
 | `stats` | object | stage-specific counts, `{}` when the stage has none |
@@ -71,11 +71,23 @@ reason in `summary`:
 }
 ```
 
-Reasons are the flag (`--quick`, `--skip-credo`), the missing package
-(`:gettext not installed`), `disabled in .quality.exs`, or `compile failed`.
+Reasons are the flag (`--quick`, `--skip-credo`, `--skip <key>`), the missing
+package (`:gettext not installed`), `disabled in .quality.exs`, `compile
+failed`, or - for a custom command declaring `skip_exit_code` - whatever the
+command itself said.
 
 **Every stage the run considered appears**, skipped ones included, so absence is
 never something a caller has to interpret.
+
+## Custom stages
+
+A project's custom stages appear in `stages[]` like any other, so **`name` is
+not one of a fixed nine** and a consumer must not switch on it exhaustively.
+Route on `status` and `findings`, and treat `name` as a label.
+
+A custom stage's `stats` are whatever its command reported, so the keys are its
+own rather than drawn from the built-in set. See
+[configuration.md](configuration.md#custom-stages).
 
 ## Finding
 

--- a/docs/stages.md
+++ b/docs/stages.md
@@ -55,6 +55,36 @@ lib/user.ex
 
 `credo: [strict: true]` is the default. Configure credo itself in `.credo.exs`.
 
+### More than one config
+
+A `.credo.exs` can declare several configs, and a check that lives in a second
+one does not run under the default. That happens when a set of files sits
+outside credo's default `files.included` - migrations are the usual case -
+because folding them into the default config would subject them to the whole
+default check set.
+
+```elixir
+credo: [configs: ["default", "migrations"]]
+```
+
+Each name is one `mix credo` invocation, in the order given, and the results
+merge into a single stage result. Findings are deduplicated on file, line,
+column and check, so two configs with overlapping `files` globs do not double
+a count. A run that fails without reporting issues names the config it came
+from, because the likeliest cause is a name `.credo.exs` does not define:
+
+```
+✗ Credo: Check failed in "migrations" (see output)
+```
+
+The runs are serial. `mix credo` can compile, and two concurrent mix runs
+against the same `_build` is exactly what the writer/reader split exists to
+prevent. The stage as a whole still runs in parallel with the other analysis
+stages.
+
+Without `configs`, one run happens with no `--config-name`, which is credo's
+own default.
+
 ## Dialyzer
 
 Runs `mix dialyzer --no-compile --format short --format dialyxir`. The short
@@ -134,6 +164,85 @@ back in, and the run then serialises the stage rather than running it alongside
 the readers.
 
 No other stage can write to your repository.
+
+## Custom stages
+
+A project's own check runs as a stage rather than beside it, declared under
+`custom:` in `.quality.exs`. It prints, times and reports like a built-in one:
+
+```
+✓ Nullability: No unsound claims (1.1s)
+✗ Nullability: 2 unsound claims (0.9s)
+○ Nullability: skipped (--skip nullability)
+```
+
+The entry forms, the option table and the validation rules are in
+[configuration.md](configuration.md#custom-stages). Two things belong here.
+
+### The reader/writer declaration is load-bearing
+
+The analysis phase runs its stages concurrently, and that is only safe while
+every one of them is a reader. A command that recompiles the project rewrites
+the beams the other stages are part-way through reading, and the stage that
+notices reports a failure about the build rather than about the code.
+
+`kind: :reader` is the default, because most custom checks read source or query
+a database. **If your command compiles, generates, or writes anything under
+`_build` or the repository, declare `kind: :writer`.** A writer runs on its
+own, before the readers, the same way the Compile stage is a serialized gate.
+
+`MIX_ENV=test mix <task>` is normally still a reader here, because the Compile
+stage has already built dev and test before the analysis phase starts. That is
+the most common shape a custom command takes and it looks like a writer, which
+is why it is worth saying.
+
+### The JSON finding contract
+
+A command that wants per-finding routing rather than a wall of text prints one
+JSON document on stdout:
+
+```json
+{
+  "summary": "2 unsound claims",
+  "stats": {"finding_count": 2},
+  "findings": [
+    {
+      "file": "apps/walt_ui/lib/walt_ui/contacts/contact.ex",
+      "line": 14,
+      "column": null,
+      "app": "walt_ui",
+      "severity": "error",
+      "check": "unsound",
+      "message": "field :email is typed non-nil but the column is nullable"
+    }
+  ]
+}
+```
+
+Only `file` and `message` are required per finding. `app` may be omitted and is
+inferred from the path. `severity` is `error`, `warning` or `info`. `summary`
+and `stats` are optional; without them the stage counts its own findings.
+
+Anything that does not parse falls through to `output` verbatim, which is the
+rule the printer and the report already follow everywhere else. `parse: :none`
+skips the attempt for a command known to print prose, so a tool that happens to
+emit JSON for some other reason is not misread.
+
+### Not applicable
+
+A custom check often has a prerequisite ExQuality cannot know about: a migrated
+test database, a running service, a generated file. Without a way to say "not
+applicable" the stage fails with an error that reads like a code problem.
+
+`skip_exit_code: 2` lets the command exit 2 and have the stage report itself as
+skipped, with the command's own first line as the reason:
+
+```
+○ Nullability: skipped (test database is not migrated)
+```
+
+Which keeps the invariant a run depends on: a stage that says nothing would
+read as a stage that passed.
 
 ## Aliased tasks
 

--- a/fixtures/with_config/.quality.exs
+++ b/fixtures/with_config/.quality.exs
@@ -6,5 +6,22 @@
   ],
   dialyzer: [
     enabled: false
+  ],
+  custom: [
+    # A command stage printing the JSON finding contract.
+    [
+      key: :house_rules,
+      name: "House rules",
+      command: "echo",
+      args: [~s({"summary": "No bare Logger calls", "findings": []})]
+    ],
+    # A command stage that says it is not applicable rather than failing.
+    [
+      key: :prerequisite,
+      name: "Prerequisite",
+      command: "sh",
+      args: ["-c", "echo 'nothing to check here'; exit 2"],
+      skip_exit_code: 2
+    ]
   ]
 ]

--- a/lib/ex_quality/config.ex
+++ b/lib/ex_quality/config.ex
@@ -44,6 +44,8 @@ defmodule ExQuality.Config do
   - `compile.warnings_as_errors` - Treat warnings as errors (default: true)
   - `credo.strict` - Use strict mode (default: true)
   - `credo.all` - Check all files (default: false)
+  - `credo.configs` - Names of the `.credo.exs` configs to run, in order
+    (default: `nil`, meaning one run with no `--config-name`)
   - `dependencies.check_unused` - Check for unused dependencies (default: true)
   - `dependencies.audit` - Run security audit if available (default: :auto)
   - `doctor.summary_only` - Show only summary (default: false)
@@ -71,7 +73,10 @@ defmodule ExQuality.Config do
     credo: [
       enabled: :auto,
       strict: true,
-      all: false
+      all: false,
+      # Names of the `.credo.exs` configs to run, in order. nil is one run with
+      # no --config-name, which is credo's own default.
+      configs: nil
     ],
     dialyzer: [
       enabled: :auto
@@ -136,10 +141,18 @@ defmodule ExQuality.Config do
     file_config = load_file_config()
     cli_config = cli_to_config(cli_opts)
 
-    defaults
-    |> deep_merge(detected)
-    |> deep_merge(file_config)
-    |> deep_merge(cli_config)
+    config =
+      defaults
+      |> deep_merge(detected)
+      |> deep_merge(file_config)
+      |> deep_merge(cli_config)
+
+    # A custom stage that is malformed does not register, and a stage that does
+    # not register is a check nobody is told is not running. That is a run to
+    # fail rather than one to weaken quietly.
+    ExQuality.Custom.validate!(config)
+
+    config
   end
 
   @doc """
@@ -196,6 +209,9 @@ defmodule ExQuality.Config do
       stage_config = Keyword.get(config, stage, [])
 
       case Keyword.get(stage_config, :disabled_by) do
+        # The generic switch carries its own spelling, because `--skip nullability`
+        # names a stage that has no `--skip-nullability` to point at.
+        {:cli, switch} -> switch
         :cli -> "--skip-#{stage}"
         :config -> "disabled in .quality.exs"
         _other -> unavailable_reason(stage)
@@ -299,7 +315,7 @@ defmodule ExQuality.Config do
   defp annotate_disabled(config, source) do
     Enum.map(config, fn
       {stage, opts} when is_list(opts) ->
-        if Keyword.get(opts, :enabled) == false do
+        if Keyword.get(opts, :enabled) == false and not Keyword.has_key?(opts, :disabled_by) do
           {stage, Keyword.put(opts, :disabled_by, source)}
         else
           {stage, opts}
@@ -325,11 +341,26 @@ defmodule ExQuality.Config do
       end)
 
     config
+    |> put_skips(opts)
     # --quick mode: skip dialyzer, skip coverage enforcement
     |> put_flag(opts, :quick)
     |> put_flag(opts, :verbose)
     |> put_test_args(opts)
     |> annotate_disabled(:cli)
+  end
+
+  # `--skip <key>` is repeatable and works for a custom stage as well as a
+  # built-in one, because `@switches` is static and a custom key cannot have a
+  # `--skip-<key>` generated for it.
+  defp put_skips(config, opts) do
+    opts
+    |> Keyword.get_values(:skip)
+    |> Enum.reduce(config, fn name, config ->
+      Keyword.put(config, String.to_atom(name),
+        enabled: false,
+        disabled_by: {:cli, "--skip #{name}"}
+      )
+    end)
   end
 
   defp put_flag(config, opts, key) do

--- a/lib/ex_quality/custom.ex
+++ b/lib/ex_quality/custom.ex
@@ -1,0 +1,327 @@
+defmodule ExQuality.Custom do
+  @moduledoc """
+  Project-defined stages, declared in `.quality.exs` under `custom:`.
+
+  A project with a house check, a schema linter, a custom mix task or a shell
+  script gate could have ExQuality's parallelism, timing, report and printer,
+  or it could have its own check, but not both. Custom stages are the way to
+  have both, and a check that runs inside `mix quality` is a check the JSON
+  report can route on.
+
+  Two layers, one mechanism:
+
+      custom: [
+        # A command. This is the case most projects want.
+        [
+          key: :nullability,
+          name: "Nullability",
+          command: "mix",
+          args: ["schema.nullability", "--format", "json"],
+          env: [{"MIX_ENV", "test"}],
+          kind: :reader
+        ],
+
+        # A module, for anything the command form cannot express.
+        [key: :house_rules, name: "House rules", module: MyApp.Quality.HouseRules]
+      ]
+
+  Every entry is a keyword list with `key` and `name`, plus either `module` or
+  `command`. Registration data lives in the entry rather than in callbacks on a
+  module so that the config file alone says what a run will contain: a stage
+  that only announces itself once it has run cannot be reported as skipped, and
+  a run that says nothing about a stage reads as a run where the stage passed.
+
+  ## Module entries
+
+  `module:` names a module exporting `run/1` and returning an
+  `ExQuality.Stage.result()`, which is the contract every built-in stage
+  already satisfies. It may also export `stage_kind/1`; a module that does not
+  is a `:reader`. See `ExQuality.Stage`.
+
+  ## Command entries
+
+  `command:` is run by `ExQuality.Stages.Command`, which documents the options
+  and the JSON finding contract.
+
+  ## What custom stages are not for
+
+  Filling gaps in built-in stages. Routing a second `mix credo` config through
+  a custom command would work and would be a mistake: the output comes back as
+  text instead of per-check findings, and per-check routing is the reason the
+  JSON report exists. If a built-in stage cannot express something its tool
+  supports, that is a bug in the stage.
+  """
+
+  alias ExQuality.Config
+  alias ExQuality.Stage
+  alias ExQuality.Stages.Command
+
+  # Reserved so a custom stage cannot shadow a built-in one. A custom stage
+  # named "Credo" that quietly replaced the real one is the same class of bug
+  # as an aliased mix task: the run still reports Credo, and it is not credo.
+  @builtin_keys [
+    :format,
+    :compile,
+    :test,
+    :credo,
+    :dialyzer,
+    :doctor,
+    :gettext,
+    :sobelow,
+    :dependencies
+  ]
+
+  @builtin_names [
+    "Format",
+    "Compile",
+    "Tests",
+    "Credo",
+    "Dialyzer",
+    "Doctor",
+    "Gettext",
+    "Sobelow",
+    "Dependencies"
+  ]
+
+  @kinds [:reader, :writer]
+  @parse_modes [:json, :none]
+
+  @doc """
+  Returns the custom stage entries in a loaded config, in declaration order.
+
+      iex> ExQuality.Custom.stages([])
+      []
+  """
+  @spec stages(keyword()) :: [keyword()]
+  def stages(config) do
+    case Keyword.get(config, :custom, []) do
+      entries when is_list(entries) -> entries
+      _other -> []
+    end
+  end
+
+  @doc """
+  Returns whether an entry reads the build or writes to it.
+
+  An entry that declares `kind:` is taken at its word. Otherwise a module entry
+  is asked, via `ExQuality.Stage.kind/2`, and a command entry is a `:reader`.
+
+      iex> ExQuality.Custom.kind([key: :a, name: "A", command: "true"], [])
+      :reader
+  """
+  @spec kind(keyword(), keyword()) :: Stage.kind()
+  def kind(entry, config) do
+    case Keyword.fetch(entry, :kind) do
+      {:ok, kind} -> kind
+      :error -> module_kind(entry, config)
+    end
+  end
+
+  defp module_kind(entry, config) do
+    case Keyword.fetch(entry, :module) do
+      {:ok, module} -> Stage.kind(module, config)
+      :error -> :reader
+    end
+  end
+
+  @doc """
+  Returns the function that runs an entry, given the run's config.
+  """
+  @spec runner(keyword()) :: (keyword() -> Stage.result())
+  def runner(entry) do
+    case Keyword.fetch(entry, :module) do
+      {:ok, module} -> &module.run/1
+      :error -> fn _config -> Command.run(entry) end
+    end
+  end
+
+  @doc """
+  Returns why a custom stage will not run, or `nil` when it will.
+
+  `--skip <key>` is read through `ExQuality.Config.skip_reason/2`, exactly as a
+  built-in stage's switch is. `enabled: false` in the entry itself is the
+  config-file spelling.
+  """
+  @spec skip_reason(keyword(), keyword()) :: String.t() | nil
+  def skip_reason(config, entry) do
+    cond do
+      reason = Config.skip_reason(config, Keyword.fetch!(entry, :key)) -> reason
+      Keyword.get(entry, :enabled, true) == false -> "disabled in .quality.exs"
+      true -> nil
+    end
+  end
+
+  @doc """
+  Raises unless every custom entry in `config` is well formed.
+
+  Custom stages are the place a config file can be wrong in ways that silently
+  weaken a run - a stage that never registers is a check nobody is told is not
+  running - so this fails the run at load time and names the offending entry
+  rather than letting it go quiet.
+  """
+  @spec validate!(keyword()) :: :ok
+  def validate!(config) do
+    entries = Keyword.get(config, :custom, [])
+
+    unless is_list(entries) and Enum.all?(entries, &Keyword.keyword?/1) do
+      Mix.raise(
+        "custom: in .quality.exs must be a list of keyword lists, got: #{inspect(entries)}"
+      )
+    end
+
+    Enum.each(entries, &validate_entry!/1)
+    validate_unique!(entries)
+
+    :ok
+  end
+
+  defp validate_unique!(entries) do
+    entries
+    |> Enum.map(&Keyword.get(&1, :key))
+    |> Enum.frequencies()
+    |> Enum.each(fn
+      {key, count} when count > 1 -> raise_entry("duplicate custom stage key #{inspect(key)}", [])
+      _unique -> :ok
+    end)
+  end
+
+  defp validate_entry!(entry) do
+    validate_key!(entry)
+    validate_name!(entry)
+    validate_implementation!(entry)
+    validate_kind!(entry)
+    validate_command_options!(entry)
+  end
+
+  defp validate_key!(entry) do
+    case Keyword.fetch(entry, :key) do
+      {:ok, key} when is_atom(key) and not is_nil(key) ->
+        if key in @builtin_keys do
+          raise_entry("key #{inspect(key)} is a built-in stage", entry)
+        end
+
+      {:ok, key} ->
+        raise_entry("key must be an atom, got: #{inspect(key)}", entry)
+
+      :error ->
+        raise_entry("missing key:", entry)
+    end
+  end
+
+  defp validate_name!(entry) do
+    case Keyword.fetch(entry, :name) do
+      {:ok, name} when is_binary(name) and name != "" ->
+        if name in @builtin_names do
+          raise_entry("name #{inspect(name)} is a built-in stage", entry)
+        end
+
+      {:ok, name} ->
+        raise_entry("name must be a non-empty string, got: #{inspect(name)}", entry)
+
+      :error ->
+        raise_entry("missing name:", entry)
+    end
+  end
+
+  defp validate_implementation!(entry) do
+    case {Keyword.fetch(entry, :module), Keyword.fetch(entry, :command)} do
+      {{:ok, _module}, {:ok, _command}} ->
+        raise_entry("declares both module: and command:, which cannot both run", entry)
+
+      {{:ok, module}, :error} ->
+        validate_module!(module, entry)
+
+      {:error, {:ok, command}} when is_binary(command) and command != "" ->
+        :ok
+
+      {:error, {:ok, command}} ->
+        raise_entry("command must be a non-empty string, got: #{inspect(command)}", entry)
+
+      {:error, :error} ->
+        raise_entry("declares neither module: nor command:", entry)
+    end
+  end
+
+  defp validate_module!(module, entry) when is_atom(module) do
+    cond do
+      not Code.ensure_loaded?(module) ->
+        raise_entry("module #{inspect(module)} could not be loaded", entry)
+
+      not function_exported?(module, :run, 1) ->
+        raise_entry("module #{inspect(module)} does not export run/1", entry)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_module!(module, entry) do
+    raise_entry("module must be a module, got: #{inspect(module)}", entry)
+  end
+
+  defp validate_kind!(entry) do
+    case Keyword.fetch(entry, :kind) do
+      {:ok, kind} when kind in @kinds -> :ok
+      {:ok, kind} -> raise_entry("kind must be :reader or :writer, got: #{inspect(kind)}", entry)
+      :error -> :ok
+    end
+  end
+
+  defp validate_command_options!(entry) do
+    validate_args!(entry)
+    validate_env!(entry)
+    validate_parse!(entry)
+    validate_skip_exit_code!(entry)
+  end
+
+  defp validate_args!(entry) do
+    args = Keyword.get(entry, :args, [])
+
+    unless is_list(args) and Enum.all?(args, &is_binary/1) do
+      raise_entry("args must be a list of strings, got: #{inspect(args)}", entry)
+    end
+  end
+
+  defp validate_env!(entry) do
+    env = Keyword.get(entry, :env, [])
+
+    valid? =
+      is_list(env) and
+        Enum.all?(env, fn
+          {name, value} -> is_binary(name) and is_binary(value)
+          _other -> false
+        end)
+
+    unless valid? do
+      raise_entry("env must be a list of {name, value} string pairs, got: #{inspect(env)}", entry)
+    end
+  end
+
+  defp validate_parse!(entry) do
+    case Keyword.fetch(entry, :parse) do
+      {:ok, mode} when mode in @parse_modes -> :ok
+      {:ok, mode} -> raise_entry("parse must be :json or :none, got: #{inspect(mode)}", entry)
+      :error -> :ok
+    end
+  end
+
+  defp validate_skip_exit_code!(entry) do
+    case Keyword.fetch(entry, :skip_exit_code) do
+      {:ok, code} when is_integer(code) ->
+        :ok
+
+      {:ok, code} ->
+        raise_entry("skip_exit_code must be an integer, got: #{inspect(code)}", entry)
+
+      :error ->
+        :ok
+    end
+  end
+
+  @spec raise_entry(String.t(), keyword()) :: no_return()
+  defp raise_entry(problem, []), do: Mix.raise("Invalid custom stage: #{problem}")
+
+  defp raise_entry(problem, entry) do
+    Mix.raise("Invalid custom stage: #{problem}\n\n    #{inspect(entry)}\n")
+  end
+end

--- a/lib/ex_quality/finding.ex
+++ b/lib/ex_quality/finding.ex
@@ -84,6 +84,77 @@ defmodule ExQuality.Finding do
   def relative_path(path) when is_binary(path), do: Path.relative_to_cwd(path)
 
   @doc """
+  Builds a finding from a decoded JSON object, or returns `:error`.
+
+  This is the reading half of the encoding in `ExQuality.Report`: it is what a
+  custom stage's command uses to report structured findings, and what a
+  consumer of a report uses to read one back.
+
+  Only `file` and `message` are required, matching the struct's enforced keys.
+  Everything else is optional and takes the struct's default when it is absent
+  or the wrong shape, because a tool that got one field wrong should still have
+  its finding read rather than dropped.
+
+  `app` is inferred from the path against `apps` when the object does not name
+  one, which is what the built-in stages do anyway and is one less thing for a
+  custom tool to get wrong. Pass `ExQuality.Umbrella.apps_paths/0` as `apps`,
+  read once rather than once per finding.
+
+      iex> alias ExQuality.Finding
+      iex> {:ok, finding} = Finding.from_map(%{"file" => "lib/a.ex", "message" => "no"})
+      iex> {finding.file, finding.message, finding.severity}
+      {"lib/a.ex", "no", :warning}
+
+      iex> ExQuality.Finding.from_map(%{"message" => "nowhere to look"})
+      :error
+  """
+  @spec from_map(map(), %{atom() => String.t()}) :: {:ok, t()} | :error
+  def from_map(map, apps \\ %{})
+
+  def from_map(%{"file" => file, "message" => message} = map, apps)
+      when is_binary(file) and is_binary(message) do
+    path = relative_path(file)
+
+    {:ok,
+     %__MODULE__{
+       file: path,
+       line: coordinate(map["line"]),
+       column: coordinate(map["column"]),
+       app: app(map["app"]) || ExQuality.Umbrella.app_for_path(path, apps),
+       severity: severity(map["severity"]),
+       check: text(map["check"]),
+       message: message,
+       raw: text(map["raw"]) || Jason.encode!(map)
+     }}
+  end
+
+  def from_map(_other, _apps), do: :error
+
+  defp coordinate(value) when is_integer(value) and value > 0, do: value
+  defp coordinate(_other), do: nil
+
+  defp text(value) when is_binary(value) and value != "", do: value
+  defp text(_other), do: nil
+
+  # A tool naming an app ex_quality has never heard of is a tool that is wrong
+  # about the tree, not a reason to grow the atom table, so only apps that
+  # already exist as atoms are taken.
+  defp app(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp app(_other), do: nil
+
+  defp severity("error"), do: :error
+  defp severity("warning"), do: :warning
+  defp severity("info"), do: :info
+  # Anything else takes the struct's default rather than being invented, so an
+  # unknown level is still rendered rather than dropped.
+  defp severity(_other), do: :warning
+
+  @doc """
   Sorts findings by file, then line, then column.
 
   Findings without a line or column sort before those that have one, so a

--- a/lib/ex_quality/stage.ex
+++ b/lib/ex_quality/stage.ex
@@ -61,7 +61,10 @@ defmodule ExQuality.Stage do
           optional(:finding_count) => non_neg_integer(),
           optional(:blocking_count) => non_neg_integer(),
           optional(:informational_count) => non_neg_integer(),
-          optional(:blocking_by_confidence) => [{String.t(), non_neg_integer()}]
+          optional(:blocking_by_confidence) => [{String.t(), non_neg_integer()}],
+          # A custom stage carries its tool's own stats, string-keyed: the names
+          # come from a config file, and atomising arbitrary ones is unbounded.
+          optional(String.t()) => term()
         }
 
   @type result :: %{

--- a/lib/ex_quality/stages/command.ex
+++ b/lib/ex_quality/stages/command.ex
@@ -1,0 +1,237 @@
+defmodule ExQuality.Stages.Command do
+  @moduledoc """
+  Runs a project's own check as a stage, described declaratively in
+  `.quality.exs`.
+
+  This is the ergonomic half of custom stages: a house rule, a schema linter, a
+  mix task or a shell script gate becomes a stage of a `mix quality` run
+  without anyone writing a module. The other half is a module implementing the
+  `ExQuality.Stage` contract, for anything the command form cannot express.
+
+      custom: [
+        [
+          key: :nullability,
+          name: "Nullability",
+          command: "mix",
+          args: ["schema.nullability", "--format", "json"],
+          env: [{"MIX_ENV", "test"}],
+          kind: :reader
+        ]
+      ]
+
+  Exit code 0 is `:ok`, anything else is `:error`. The command is run with
+  `stderr_to_stdout: true`, as every other shelling stage is, so a tool that
+  writes its complaint to stderr is not thrown away.
+
+  ## The finding contract
+
+  A command that wants structured findings prints one JSON document on stdout:
+
+      {
+        "summary": "2 unsound claims",
+        "stats": {"finding_count": 2},
+        "findings": [
+          {
+            "file": "lib/contacts/contact.ex",
+            "line": 14,
+            "column": null,
+            "app": "walt_ui",
+            "severity": "error",
+            "check": "unsound",
+            "message": "field :email is typed non-nil but the column is nullable"
+          }
+        ]
+      }
+
+  Only `file` and `message` are required per finding. `app` may be omitted and
+  is inferred from the path. See `ExQuality.Finding.from_map/2`.
+
+  Anything that does not parse falls through to `output` verbatim, which is the
+  rule the printer and the report already follow. `parse: :none` skips the
+  attempt for a command known to print prose, so a tool that happens to emit
+  JSON for some other reason is not misread.
+
+  ## Not applicable
+
+  A custom check often has a prerequisite ExQuality cannot know about: a
+  migrated test database, a running service, a generated file. Without a way to
+  say "not applicable" the stage fails with an error that reads like a code
+  problem. `skip_exit_code: 2` lets the command exit 2 and have the stage
+  report `:skipped` with the command's own first line as the reason, which
+  keeps the invariant that a stage saying nothing would read as a stage that
+  passed.
+
+  ## Reader versus writer
+
+  `kind: :reader` is the default, and it is what most custom checks are: they
+  read source, or query a database. A command that compiles, generates, or
+  writes anything under `_build` or the repository must declare
+  `kind: :writer`, because the analysis phase runs its readers concurrently and
+  a stage that rewrites the beams underneath them makes another stage report a
+  failure about the build rather than about the code.
+
+  `MIX_ENV=test mix <task>` is normally still a reader here, because the
+  Compile stage has already built dev and test before the analysis phase
+  starts. That is the most common shape a custom command takes and it looks
+  like a writer, so it is worth saying.
+  """
+
+  alias ExQuality.Finding
+  alias ExQuality.Json
+  alias ExQuality.Umbrella
+
+  @doc """
+  Runs one custom command entry and returns its stage result.
+
+  The entry is the keyword list from `.quality.exs`, already validated by
+  `ExQuality.Custom.validate!/1`.
+  """
+  @spec run(keyword()) :: ExQuality.Stage.result()
+  def run(entry) do
+    name = Keyword.fetch!(entry, :name)
+    command = Keyword.fetch!(entry, :command)
+    start_time = System.monotonic_time(:millisecond)
+
+    outcome = execute(command, Keyword.get(entry, :args, []), cmd_opts(entry))
+
+    duration_ms = System.monotonic_time(:millisecond) - start_time
+
+    case outcome do
+      {:ok, output, exit_code} -> result(entry, name, output, exit_code, duration_ms)
+      {:error, reason} -> unrunnable(name, command, reason, duration_ms)
+    end
+  end
+
+  defp cmd_opts(entry) do
+    opts = [env: Keyword.get(entry, :env, []), stderr_to_stdout: true]
+
+    case Keyword.get(entry, :cd) do
+      nil -> opts
+      cd -> Keyword.put(opts, :cd, cd)
+    end
+  end
+
+  # A command that is not on the PATH, or a `cd` that does not exist, raises
+  # rather than returning an exit code. That is still a stage failure and not a
+  # crash of the run, because every other stage reports its own trouble.
+  defp execute(command, args, opts) do
+    {output, exit_code} = System.cmd(command, args, opts)
+    {:ok, output, exit_code}
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+
+  defp unrunnable(name, command, reason, duration_ms) do
+    %{
+      name: name,
+      status: :error,
+      output: "#{command} could not be run: #{reason}\n",
+      stats: %{},
+      summary: "Command could not be run",
+      duration_ms: duration_ms
+    }
+  end
+
+  defp result(entry, name, output, exit_code, duration_ms) do
+    if exit_code == Keyword.get(entry, :skip_exit_code, :never) do
+      %{
+        name: name,
+        status: :skipped,
+        output: output,
+        stats: %{},
+        summary: skip_reason(output),
+        duration_ms: duration_ms
+      }
+    else
+      report(entry, name, output, exit_code, duration_ms)
+    end
+  end
+
+  defp skip_reason(output) do
+    output
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.find("not applicable", &(&1 != ""))
+  end
+
+  defp report(entry, name, output, exit_code, duration_ms) do
+    status = if exit_code == 0, do: :ok, else: :error
+
+    case document(entry, output) do
+      nil ->
+        %{
+          name: name,
+          status: status,
+          output: output,
+          stats: %{},
+          summary: fallback_summary(status),
+          duration_ms: duration_ms
+        }
+
+      document ->
+        parsed(document, name, status, output, duration_ms)
+    end
+  end
+
+  defp document(entry, output) do
+    if Keyword.get(entry, :parse, :json) == :none do
+      nil
+    else
+      case Json.decode(output) do
+        {:ok, %{} = document} -> document
+        _no_document -> nil
+      end
+    end
+  end
+
+  defp parsed(document, name, status, output, duration_ms) do
+    findings = findings(document)
+
+    %{
+      name: name,
+      status: status,
+      output: output,
+      findings: findings,
+      stats: stats(document, findings),
+      summary: summary(document, findings, status),
+      duration_ms: duration_ms
+    }
+  end
+
+  defp findings(%{"findings" => findings}) when is_list(findings) do
+    apps = Umbrella.apps_paths()
+
+    findings
+    |> Enum.flat_map(fn
+      %{} = finding ->
+        case Finding.from_map(finding, apps) do
+          {:ok, parsed} -> [parsed]
+          :error -> []
+        end
+
+      _other ->
+        []
+    end)
+    |> Finding.sort()
+  end
+
+  defp findings(_document), do: []
+
+  # A custom stage's stats are its tool's own, so they are carried string-keyed
+  # rather than atomised: the names come from a config file, and turning
+  # arbitrary ones into atoms is unbounded.
+  defp stats(%{"stats" => %{} = stats}, _findings), do: stats
+  defp stats(_document, findings), do: %{"finding_count" => length(findings)}
+
+  defp summary(%{"summary" => summary}, _findings, _status) when is_binary(summary), do: summary
+  defp summary(_document, [], status), do: fallback_summary(status)
+
+  defp summary(_document, findings, _status) do
+    count = length(findings)
+
+    "#{count} finding#{if count == 1, do: "", else: "s"}"
+  end
+
+  defp fallback_summary(:ok), do: "Passed"
+  defp fallback_summary(:error), do: "Failed (see output)"
+end

--- a/lib/ex_quality/stages/credo.ex
+++ b/lib/ex_quality/stages/credo.ex
@@ -18,6 +18,24 @@ defmodule ExQuality.Stages.Credo do
   document is reported with whatever credo did say, which is what a version too
   old to know `--format json` produces.
 
+  ## Multiple configs
+
+  A `.credo.exs` can declare more than one config, and a check that lives in a
+  second config does not run under the default one. `credo: [configs: ["default",
+  "migrations"]]` runs `mix credo` once per name, in order, and merges the
+  results into one stage result. Without it, one run happens with no
+  `--config-name`, which is credo's own default.
+
+  The runs are serial, not concurrent. `mix credo` runs with `MIX_ENV=dev` and
+  can compile, and two concurrent mix runs against the same `_build` is the
+  hazard the reader/writer split in the analysis phase exists to avoid. The
+  stage as a whole still runs in parallel with every other analysis stage.
+
+  Findings are deduplicated on `{file, line, column, check}` before sorting,
+  because two configs whose `files` globs overlap can report the same issue
+  twice, and a doubled count is worse than a missed one: it is not obviously
+  wrong.
+
   Note: Credo does not support auto-fix. All issues must be manually resolved.
   """
 
@@ -41,6 +59,8 @@ defmodule ExQuality.Stages.Credo do
 
   - `strict` - Use `--strict` mode (default: true)
   - `all` - Use `--all` flag to check all files (default: false)
+  - `configs` - Names of the `.credo.exs` configs to run, in order
+    (default: `nil`, meaning one run with no `--config-name`)
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
@@ -58,57 +78,97 @@ defmodule ExQuality.Stages.Credo do
     strict = Keyword.get(credo_config, :strict, true)
     all = Keyword.get(credo_config, :all, false)
 
+    runs =
+      credo_config
+      |> Keyword.get(:configs)
+      |> config_names()
+      |> Enum.map(&run_config(&1, strict, all))
+
+    report(runs, System.monotonic_time(:millisecond) - start_time)
+  end
+
+  # No names, or an empty list, is one run under credo's own default config,
+  # which is what a project that has never heard of this option gets.
+  defp config_names(names) when is_list(names) and names != [], do: names
+  defp config_names(_none), do: [nil]
+
+  defp run_config(name, strict, all) do
     {output, exit_code} =
-      System.cmd("mix", build_args(strict, all),
+      System.cmd("mix", build_args(strict, all, name),
         env: [{"MIX_ENV", "dev"}],
         stderr_to_stdout: true
       )
 
-    duration_ms = System.monotonic_time(:millisecond) - start_time
+    issues =
+      case Json.decode(output) do
+        {:ok, %{"issues" => issues}} when is_list(issues) -> issues
+        _no_report -> nil
+      end
 
-    case Json.decode(output) do
-      {:ok, %{"issues" => issues}} when is_list(issues) ->
-        report(issues, output, exit_code, duration_ms)
+    %{name: name, output: output, exit_code: exit_code, issues: issues}
+  end
 
-      _no_report ->
-        unparsed(output, exit_code, duration_ms)
+  defp build_args(strict, all, name) do
+    args = ["credo", "--format", "json"]
+    args = if strict, do: args ++ ["--strict"], else: args
+    args = if all, do: args ++ ["--all"], else: args
+
+    if name, do: args ++ ["--config-name", name], else: args
+  end
+
+  defp report(runs, duration_ms) do
+    output = merged_output(runs)
+
+    case Enum.find(runs, &broken?/1) do
+      # A run that printed no report and failed either broke or is too old to
+      # know `--format json`. There is nothing to parse, so credo's own output
+      # stands on its own, attributed to the config that produced it.
+      %{name: name} ->
+        %{
+          name: "Credo",
+          status: :error,
+          output: output,
+          stats: %{},
+          summary: "Credo did not produce a report#{for_config(name)}",
+          duration_ms: duration_ms
+        }
+
+      nil ->
+        runs |> parsed_findings() |> merged(runs, output, duration_ms)
     end
   end
 
-  defp build_args(strict, all) do
-    args = ["credo", "--format", "json"]
-    args = if strict, do: args ++ ["--strict"], else: args
+  defp broken?(%{issues: nil, exit_code: exit_code}), do: exit_code != 0
+  defp broken?(_run), do: false
 
-    if all, do: args ++ ["--all"], else: args
+  defp merged([], runs, output, duration_ms) do
+    case Enum.find(runs, &(&1.exit_code != 0)) do
+      # Credo reported no issues and failed anyway, which is credo saying
+      # something about itself rather than about the code. The most likely
+      # cause is a config name `.credo.exs` does not define, so name it.
+      %{name: name} ->
+        %{
+          name: "Credo",
+          status: :error,
+          output: output,
+          stats: %{issue_count: 0},
+          summary: "Check failed#{for_config(name)} (see output)",
+          duration_ms: duration_ms
+        }
+
+      nil ->
+        %{
+          name: "Credo",
+          status: :ok,
+          output: output,
+          stats: %{issue_count: 0},
+          summary: "No issues",
+          duration_ms: duration_ms
+        }
+    end
   end
 
-  defp report([], output, 0, duration_ms) do
-    %{
-      name: "Credo",
-      status: :ok,
-      output: output,
-      stats: %{issue_count: 0},
-      summary: "No issues",
-      duration_ms: duration_ms
-    }
-  end
-
-  # Credo reported no issues and failed anyway, which is credo saying something
-  # about itself rather than about the code. Its output is the answer.
-  defp report([], output, _exit_code, duration_ms) do
-    %{
-      name: "Credo",
-      status: :error,
-      output: output,
-      stats: %{issue_count: 0},
-      summary: "Check failed (see output)",
-      duration_ms: duration_ms
-    }
-  end
-
-  defp report(issues, output, _exit_code, duration_ms) do
-    parsed = findings(issues)
-
+  defp merged(parsed, _runs, output, duration_ms) do
     %{
       name: "Credo",
       status: :error,
@@ -120,38 +180,37 @@ defmodule ExQuality.Stages.Credo do
     }
   end
 
-  # A run that printed no report either passed silently or broke. Either way
-  # there is nothing to parse, so the tool's output stands on its own.
-  defp unparsed(output, 0, duration_ms) do
-    %{
-      name: "Credo",
-      status: :ok,
-      output: output,
-      stats: %{issue_count: 0},
-      summary: "No issues",
-      duration_ms: duration_ms
-    }
-  end
+  defp for_config(nil), do: ""
+  defp for_config(name), do: ~s( in "#{name}")
 
-  defp unparsed(output, _exit_code, duration_ms) do
-    %{
-      name: "Credo",
-      status: :error,
-      output: output,
-      stats: %{},
-      summary: "Credo did not produce a report",
-      duration_ms: duration_ms
-    }
+  # A single unnamed run's output is passed through untouched, because there is
+  # nothing to attribute it to. Named runs are labelled so a reader can tell
+  # which config produced which half of the output.
+  defp merged_output([%{name: nil, output: output}]), do: output
+
+  defp merged_output(runs) do
+    Enum.map_join(runs, "\n", fn %{name: name, output: output} ->
+      "── credo --config-name #{name} ──\n#{output}"
+    end)
   end
 
   # Findings are carried as `{finding, category}` pairs, because the summary
   # breaks down by category and `check` has already been spent on the check
   # module, which is the more specific of the two.
-  defp findings(issues) do
+  defp parsed_findings(runs) do
     # Read the umbrella layout once rather than once per finding.
     apps = Umbrella.apps_paths()
 
-    Enum.flat_map(issues, &finding(&1, apps))
+    runs
+    |> Enum.flat_map(&(&1.issues || []))
+    |> Enum.flat_map(&finding(&1, apps))
+    |> Enum.uniq_by(&identity/1)
+  end
+
+  # Two configs whose `files` globs overlap report the same issue twice, and a
+  # doubled count is worse than a missed one because it is not obviously wrong.
+  defp identity({finding, _category}) do
+    {finding.file, finding.line, finding.column, finding.check}
   end
 
   defp finding(%{"message" => message} = issue, apps) when is_binary(message) do

--- a/lib/mix/tasks/quality.ex
+++ b/lib/mix/tasks/quality.ex
@@ -26,6 +26,7 @@ defmodule Mix.Tasks.Quality do
   - `--skip-gettext` - Skip Gettext translation checks
   - `--skip-sobelow` - Skip Sobelow security analysis
   - `--skip-dependencies` - Skip dependency checks (unused deps and security audit)
+  - `--skip KEY` - Skip any stage by key, built-in or custom; repeatable
   - `--verbose` - Show full output even on success
   - `--format json` - Write a JSON report to stdout, human output to stderr
   - `--report PATH` - Write a JSON report to PATH, human output to stdout
@@ -75,6 +76,14 @@ defmodule Mix.Tasks.Quality do
   Create `.quality.exs` in your project root to customize behavior
   or override auto-detection. See `Config` for options.
 
+  ## Custom Stages
+
+  A project's own check - a house rule, a schema linter, a shell script gate -
+  runs as a stage of the run rather than beside it, declared under `custom:` in
+  `.quality.exs`. It gets the same parallelism, timing, printer and JSON report
+  as a built-in stage, which is what lets a caller route its findings. See
+  `ExQuality.Custom`.
+
   ## Example Output
 
       Running quality checks...
@@ -121,6 +130,7 @@ defmodule Mix.Tasks.Quality do
   use Mix.Task
 
   alias ExQuality.Config
+  alias ExQuality.Custom
   alias ExQuality.Finding
   alias ExQuality.Printer
   alias ExQuality.Report
@@ -154,6 +164,7 @@ defmodule Mix.Tasks.Quality do
     skip_gettext: :boolean,
     skip_sobelow: :boolean,
     skip_dependencies: :boolean,
+    skip: :keep,
     verbose: :boolean,
     format: :string,
     report: :string
@@ -268,10 +279,7 @@ defmodule Mix.Tasks.Quality do
       # reader knows what this run is not evidence for.
       Enum.each(skipped, &Printer.print_result/1)
 
-      {writers, readers} =
-        Enum.split_with(stages, fn {_stage, module, _name} ->
-          Stage.kind(module, config) == :writer
-        end)
+      {writers, readers} = Enum.split_with(stages, &(&1.kind == :writer))
 
       # Writers go first, one at a time. A stage that recompiles the project
       # rewrites the beams the readers are part-way through, and the reader
@@ -286,8 +294,8 @@ defmodule Mix.Tasks.Quality do
     end
   end
 
-  defp run_stage({_stage, module, _name}, config) do
-    result = module.run(config)
+  defp run_stage(stage, config) do
+    result = stage.run.(config)
     Printer.print_result(result)
     result
   end
@@ -296,14 +304,51 @@ defmodule Mix.Tasks.Quality do
   # Tests always run (but coverage enforcement is skipped in quick mode).
   defp build_analysis_stages(config) do
     {stages, skipped} =
-      Enum.reduce(@analysis_stages, {[], []}, fn {stage, module, name}, {stages, skipped} ->
-        case stage_skip_reason(config, stage) do
-          nil -> {[{stage, module, name} | stages], skipped}
-          reason -> {stages, [Stage.skipped(name, reason) | skipped]}
+      Enum.reduce(candidate_stages(config), {[], []}, fn stage, {stages, skipped} ->
+        case stage.skip_reason do
+          nil -> {[stage | stages], skipped}
+          reason -> {stages, [Stage.skipped(stage.name, reason) | skipped]}
         end
       end)
 
-    {Enum.reverse([{:test, Test, "Tests"} | stages]), Enum.reverse(skipped)}
+    {Enum.reverse([test_stage(config) | stages]), Enum.reverse(skipped)}
+  end
+
+  # Built-ins first, then the project's own stages, in declaration order. Both
+  # kinds are the same shape from here on, which is why the writer/reader
+  # split, the printer and the report need to know nothing about custom stages.
+  defp candidate_stages(config) do
+    builtin =
+      Enum.map(@analysis_stages, fn {key, module, name} ->
+        stage(
+          key,
+          name,
+          Stage.kind(module, config),
+          &module.run/1,
+          stage_skip_reason(config, key)
+        )
+      end)
+
+    custom =
+      Enum.map(Custom.stages(config), fn entry ->
+        stage(
+          Keyword.fetch!(entry, :key),
+          Keyword.fetch!(entry, :name),
+          Custom.kind(entry, config),
+          Custom.runner(entry),
+          Custom.skip_reason(config, entry)
+        )
+      end)
+
+    builtin ++ custom
+  end
+
+  defp test_stage(config) do
+    stage(:test, "Tests", Stage.kind(Test, config), &Test.run/1, nil)
+  end
+
+  defp stage(key, name, kind, run, skip_reason) do
+    %{key: key, name: name, kind: kind, run: run, skip_reason: skip_reason}
   end
 
   # The stages of a run that stopped before the analysis phase: the ones that
@@ -311,7 +356,7 @@ defmodule Mix.Tasks.Quality do
   defp analysis_stages_not_run(config, reason) do
     {stages, skipped} = build_analysis_stages(config)
 
-    skipped ++ Enum.map(stages, fn {_stage, _module, name} -> Stage.skipped(name, reason) end)
+    skipped ++ Enum.map(stages, &Stage.skipped(&1.name, reason))
   end
 
   defp stage_skip_reason(config, :dialyzer) do

--- a/test/ex_quality/custom_test.exs
+++ b/test/ex_quality/custom_test.exs
@@ -1,0 +1,188 @@
+defmodule ExQuality.CustomTest do
+  use ExUnit.Case, async: true
+
+  alias ExQuality.Custom
+
+  defmodule Runnable do
+    @moduledoc false
+    def run(_config), do: %{}
+  end
+
+  defmodule Writer do
+    @moduledoc false
+    def run(_config), do: %{}
+    def stage_kind(_config), do: :writer
+  end
+
+  defmodule NotAStage do
+    @moduledoc false
+    def check, do: :ok
+  end
+
+  defp command_entry(attrs \\ []) do
+    Keyword.merge([key: :nullability, name: "Nullability", command: "mix"], attrs)
+  end
+
+  defp module_entry(attrs \\ []) do
+    Keyword.merge([key: :house_rules, name: "House rules", module: Runnable], attrs)
+  end
+
+  describe "stages/1" do
+    test "returns the entries in declaration order" do
+      entries = [command_entry(), module_entry()]
+
+      assert Enum.map(Custom.stages(custom: entries), &Keyword.fetch!(&1, :key)) ==
+               [:nullability, :house_rules]
+    end
+
+    test "a config with no custom key has no custom stages" do
+      assert Custom.stages([]) == []
+    end
+  end
+
+  describe "kind/2" do
+    test "a command entry is a reader by default" do
+      assert Custom.kind(command_entry(), []) == :reader
+    end
+
+    test "an entry that declares a kind is taken at its word" do
+      assert Custom.kind(command_entry(kind: :writer), []) == :writer
+    end
+
+    test "a module entry is asked" do
+      assert Custom.kind(module_entry(), []) == :reader
+      assert Custom.kind(module_entry(module: Writer), []) == :writer
+    end
+  end
+
+  describe "runner/1" do
+    test "a module entry runs the module" do
+      assert Custom.runner(module_entry()).([]) == %{}
+    end
+  end
+
+  describe "skip_reason/2" do
+    test "a stage that will run has no reason" do
+      assert Custom.skip_reason([], command_entry()) == nil
+    end
+
+    test "enabled: false in the entry names the file" do
+      assert Custom.skip_reason([], command_entry(enabled: false)) == "disabled in .quality.exs"
+    end
+
+    test "--skip names itself, because there is no --skip-nullability to point at" do
+      config = [nullability: [enabled: false, disabled_by: {:cli, "--skip nullability"}]]
+
+      assert Custom.skip_reason(config, command_entry()) == "--skip nullability"
+    end
+  end
+
+  describe "validate!/1" do
+    test "accepts both entry forms" do
+      assert Custom.validate!(custom: [command_entry(), module_entry()]) == :ok
+    end
+
+    test "accepts a config with no custom stages" do
+      assert Custom.validate!([]) == :ok
+    end
+
+    test "rejects a missing key" do
+      assert_raise Mix.Error, ~r/missing key:/, fn ->
+        Custom.validate!(custom: [[name: "Nullability", command: "mix"]])
+      end
+    end
+
+    test "rejects a missing name" do
+      assert_raise Mix.Error, ~r/missing name:/, fn ->
+        Custom.validate!(custom: [[key: :nullability, command: "mix"]])
+      end
+    end
+
+    test "rejects an entry with neither module nor command" do
+      assert_raise Mix.Error, ~r/declares neither module: nor command:/, fn ->
+        Custom.validate!(custom: [[key: :nullability, name: "Nullability"]])
+      end
+    end
+
+    test "rejects an entry with both" do
+      assert_raise Mix.Error, ~r/declares both module: and command:/, fn ->
+        Custom.validate!(custom: [command_entry(module: Runnable)])
+      end
+    end
+
+    test "rejects a key that shadows a built-in stage" do
+      assert_raise Mix.Error, ~r/key :credo is a built-in stage/, fn ->
+        Custom.validate!(custom: [command_entry(key: :credo)])
+      end
+    end
+
+    test "rejects a name that shadows a built-in stage" do
+      assert_raise Mix.Error, ~r/name "Credo" is a built-in stage/, fn ->
+        Custom.validate!(custom: [command_entry(name: "Credo")])
+      end
+    end
+
+    test "rejects a duplicate key across entries" do
+      assert_raise Mix.Error, ~r/duplicate custom stage key :nullability/, fn ->
+        Custom.validate!(custom: [command_entry(), command_entry(name: "Other")])
+      end
+    end
+
+    test "rejects a kind that is neither reader nor writer" do
+      assert_raise Mix.Error, ~r/kind must be :reader or :writer/, fn ->
+        Custom.validate!(custom: [command_entry(kind: :whenever)])
+      end
+    end
+
+    test "rejects a module that cannot be loaded" do
+      assert_raise Mix.Error, ~r/could not be loaded/, fn ->
+        Custom.validate!(custom: [module_entry(module: NoSuchModule.Anywhere)])
+      end
+    end
+
+    test "rejects a module that does not export run/1" do
+      assert_raise Mix.Error, ~r/does not export run\/1/, fn ->
+        Custom.validate!(custom: [module_entry(module: NotAStage)])
+      end
+    end
+
+    test "rejects args that are not strings" do
+      assert_raise Mix.Error, ~r/args must be a list of strings/, fn ->
+        Custom.validate!(custom: [command_entry(args: [:schema])])
+      end
+    end
+
+    test "rejects env that is not string pairs" do
+      assert_raise Mix.Error, ~r/env must be a list of/, fn ->
+        Custom.validate!(custom: [command_entry(env: [{"MIX_ENV", :test}])])
+      end
+    end
+
+    test "rejects an unknown parse mode" do
+      assert_raise Mix.Error, ~r/parse must be :json or :none/, fn ->
+        Custom.validate!(custom: [command_entry(parse: :yaml)])
+      end
+    end
+
+    test "rejects a non-integer skip_exit_code" do
+      assert_raise Mix.Error, ~r/skip_exit_code must be an integer/, fn ->
+        Custom.validate!(custom: [command_entry(skip_exit_code: "2")])
+      end
+    end
+
+    test "rejects a custom: that is not a list of keyword lists" do
+      assert_raise Mix.Error, ~r/must be a list of keyword lists/, fn ->
+        Custom.validate!(custom: [key: :nullability, name: "Nullability", command: "mix"])
+      end
+    end
+
+    test "names the offending entry" do
+      error =
+        assert_raise Mix.Error, fn ->
+          Custom.validate!(custom: [command_entry(kind: :whenever)])
+        end
+
+      assert Exception.message(error) =~ ~s(key: :nullability)
+    end
+  end
+end

--- a/test/ex_quality/finding_test.exs
+++ b/test/ex_quality/finding_test.exs
@@ -152,4 +152,91 @@ defmodule ExQuality.FindingTest do
       refute Finding.render([finding(line: 1)]) =~ "──"
     end
   end
+
+  describe "from_map/2" do
+    test "reads every field a tool reports" do
+      {:ok, parsed} =
+        Finding.from_map(%{
+          "file" => "lib/user.ex",
+          "line" => 14,
+          "column" => 3,
+          "app" => "ex_quality",
+          "severity" => "error",
+          "check" => "unsound",
+          "message" => "typed non-nil over a nullable column"
+        })
+
+      assert %Finding{
+               file: "lib/user.ex",
+               line: 14,
+               column: 3,
+               app: :ex_quality,
+               severity: :error,
+               check: "unsound",
+               message: "typed non-nil over a nullable column"
+             } = parsed
+    end
+
+    test "requires only a file and a message" do
+      assert {:ok, parsed} = Finding.from_map(%{"file" => "lib/a.ex", "message" => "no"})
+
+      assert %Finding{line: nil, column: nil, app: nil, check: nil, severity: :warning} = parsed
+    end
+
+    test "rejects an entry with nowhere to look" do
+      assert Finding.from_map(%{"message" => "no file"}) == :error
+      assert Finding.from_map(%{"file" => "lib/a.ex"}) == :error
+      assert Finding.from_map(%{"file" => 1, "message" => "no"}) == :error
+    end
+
+    test "reads each severity, and defaults an unknown one rather than dropping it" do
+      for {given, expected} <- [{"error", :error}, {"warning", :warning}, {"info", :info}] do
+        assert {:ok, %{severity: ^expected}} =
+                 Finding.from_map(%{"file" => "a.ex", "message" => "x", "severity" => given})
+      end
+
+      assert {:ok, %{severity: :warning}} =
+               Finding.from_map(%{"file" => "a.ex", "message" => "x", "severity" => "critical"})
+    end
+
+    test "ignores a line or column that is not a position" do
+      assert {:ok, %{line: nil, column: nil}} =
+               Finding.from_map(%{
+                 "file" => "a.ex",
+                 "message" => "x",
+                 "line" => 0,
+                 "column" => "3"
+               })
+    end
+
+    test "infers the app from the path when the tool does not name one" do
+      assert {:ok, %{app: :web}} =
+               Finding.from_map(
+                 %{"file" => "apps/web/lib/user.ex", "message" => "x"},
+                 %{web: "apps/web"}
+               )
+    end
+
+    test "ignores an app ex_quality has never heard of" do
+      assert {:ok, %{app: nil}} =
+               Finding.from_map(%{
+                 "file" => "a.ex",
+                 "message" => "x",
+                 "app" => "no_such_app_here"
+               })
+    end
+
+    test "normalises an absolute path against the run's root" do
+      absolute = Path.join(File.cwd!(), "lib/user.ex")
+
+      assert {:ok, %{file: "lib/user.ex"}} =
+               Finding.from_map(%{"file" => absolute, "message" => "x"})
+    end
+
+    test "keeps the object each finding came from" do
+      {:ok, parsed} = Finding.from_map(%{"file" => "lib/a.ex", "message" => "no"})
+
+      assert parsed.raw =~ "lib/a.ex"
+    end
+  end
 end

--- a/test/ex_quality/stages/command_test.exs
+++ b/test/ex_quality/stages/command_test.exs
@@ -1,0 +1,238 @@
+defmodule ExQuality.Stages.CommandTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias ExQuality.Stages.Command
+
+  @entry [key: :nullability, name: "Nullability", command: "mix", args: ["schema.nullability"]]
+
+  defp document(attrs), do: Jason.encode!(attrs, pretty: true)
+
+  defp finding(attrs) do
+    Map.merge(
+      %{
+        "file" => "lib/my_app/contact.ex",
+        "line" => 14,
+        "severity" => "error",
+        "check" => "unsound",
+        "message" => "field :email is typed non-nil but the column is nullable"
+      },
+      attrs
+    )
+  end
+
+  describe "run/1 - the command itself" do
+    test "passes the command, args and env through to System.cmd" do
+      System
+      |> expect(:cmd, fn "mix", ["schema.nullability", "--format", "json"], opts ->
+        assert opts[:env] == [{"MIX_ENV", "test"}]
+        assert opts[:stderr_to_stdout]
+        refute Keyword.has_key?(opts, :cd)
+        {"", 0}
+      end)
+
+      entry =
+        Keyword.merge(@entry,
+          args: ["schema.nullability", "--format", "json"],
+          env: [{"MIX_ENV", "test"}]
+        )
+
+      assert Command.run(entry).status == :ok
+    end
+
+    test "runs in cd when the entry names one" do
+      System
+      |> expect(:cmd, fn "mix", _args, opts ->
+        assert opts[:cd] == "apps/web"
+        {"", 0}
+      end)
+
+      assert Command.run(Keyword.put(@entry, :cd, "apps/web")).status == :ok
+    end
+
+    test "reports a command that could not be run rather than crashing the run" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> raise ErlangError, original: :enoent end)
+
+      result = Command.run(@entry)
+
+      assert result.status == :error
+      assert result.summary == "Command could not be run"
+      assert result.output =~ "mix could not be run"
+      assert result.name == "Nullability"
+    end
+  end
+
+  describe "run/1 - exit codes" do
+    test "exit 0 passes" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"all good\n", 0} end)
+
+      result = Command.run(@entry)
+
+      assert result.status == :ok
+      assert result.summary == "Passed"
+      assert result.output == "all good\n"
+    end
+
+    test "any other exit code fails" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"boom\n", 3} end)
+
+      result = Command.run(@entry)
+
+      assert result.status == :error
+      assert result.summary == "Failed (see output)"
+      assert result.output == "boom\n"
+    end
+  end
+
+  describe "run/1 - the finding contract" do
+    test "parses findings out of a JSON document" do
+      body =
+        document(%{
+          "summary" => "2 unsound claims",
+          "stats" => %{"finding_count" => 2},
+          "findings" => [
+            finding(%{"file" => "lib/my_app/user.ex", "line" => 3}),
+            finding(%{})
+          ]
+        })
+
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {body, 1} end)
+
+      result = Command.run(@entry)
+
+      assert result.status == :error
+      assert result.summary == "2 unsound claims"
+      assert result.stats == %{"finding_count" => 2}
+
+      assert [contact, user] = ExQuality.Stage.findings(result)
+
+      assert %{file: "lib/my_app/contact.ex", line: 14, severity: :error, check: "unsound"} =
+               contact
+
+      assert %{file: "lib/my_app/user.ex", line: 3} = user
+    end
+
+    test "counts the findings when the document gives no summary or stats" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {document(%{"findings" => [finding(%{})]}), 1}
+      end)
+
+      result = Command.run(@entry)
+
+      assert result.summary == "1 finding"
+      assert result.stats == %{"finding_count" => 1}
+    end
+
+    test "reads the document out of output the compiler wrote to as well" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {"Compiling 3 files (.ex)\n" <> document(%{"findings" => [finding(%{})]}), 1}
+      end)
+
+      assert [%{file: "lib/my_app/contact.ex"}] =
+               ExQuality.Stage.findings(Command.run(@entry))
+    end
+
+    test "leaves out a finding with nowhere to look" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {document(%{"findings" => [%{"message" => "something"}, finding(%{})]}), 1}
+      end)
+
+      assert [%{file: "lib/my_app/contact.ex"}] =
+               ExQuality.Stage.findings(Command.run(@entry))
+    end
+
+    test "falls through to output verbatim when nothing parses" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"** (Mix) no such task\n", 1} end)
+
+      result = Command.run(@entry)
+
+      assert result.status == :error
+      assert result.summary == "Failed (see output)"
+      assert result.output == "** (Mix) no such task\n"
+      assert ExQuality.Stage.findings(result) == []
+    end
+
+    test "parse: :none never reads a document, even from output that is one" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {document(%{"summary" => "hijacked", "findings" => [finding(%{})]}), 1}
+      end)
+
+      result = Command.run(Keyword.put(@entry, :parse, :none))
+
+      assert result.summary == "Failed (see output)"
+      assert ExQuality.Stage.findings(result) == []
+    end
+
+    test "tags a finding with the umbrella app its file belongs to" do
+      ExQuality.Umbrella
+      |> stub(:apps_paths, fn -> %{web: "apps/web"} end)
+
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {document(%{"findings" => [finding(%{"file" => "apps/web/lib/user.ex"})]}), 1}
+      end)
+
+      assert [%{app: :web}] = ExQuality.Stage.findings(Command.run(@entry))
+    end
+  end
+
+  describe "run/1 - skip_exit_code" do
+    test "reports the declared exit code as skipped, with the command's own reason" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {"\ntest database is not migrated\n", 2}
+      end)
+
+      result = Command.run(Keyword.put(@entry, :skip_exit_code, 2))
+
+      assert result.status == :skipped
+      assert result.summary == "test database is not migrated"
+      assert result.output =~ "not migrated"
+    end
+
+    test "says something even when the command exited quietly" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"", 2} end)
+
+      assert Command.run(Keyword.put(@entry, :skip_exit_code, 2)).summary == "not applicable"
+    end
+
+    test "leaves every other exit code alone" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"boom\n", 1} end)
+
+      assert Command.run(Keyword.put(@entry, :skip_exit_code, 2)).status == :error
+    end
+
+    test "without it, a non-zero exit is a failure" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts -> {"not migrated\n", 2} end)
+
+      assert Command.run(@entry).status == :error
+    end
+  end
+
+  describe "run/1 - timing" do
+    test "records execution duration" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        Process.sleep(10)
+        {"", 0}
+      end)
+
+      result = Command.run(@entry)
+
+      assert result.duration_ms >= 10
+      assert result.duration_ms < 5_000
+    end
+  end
+end

--- a/test/ex_quality/stages/credo_test.exs
+++ b/test/ex_quality/stages/credo_test.exs
@@ -273,6 +273,126 @@ defmodule ExQuality.Stages.CredoTest do
     end
   end
 
+  describe "run/1 - multiple configs" do
+    test "runs credo once per named config, in order" do
+      System
+      |> expect(:cmd, fn "mix", args, _opts ->
+        assert args == @args ++ ["--config-name", "default"]
+        {report([]), 0}
+      end)
+      |> expect(:cmd, fn "mix", args, _opts ->
+        assert args == @args ++ ["--config-name", "migrations"]
+        {report([]), 0}
+      end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.status == :ok
+      assert result.summary == "No issues"
+    end
+
+    test "merges the findings of every config into one result" do
+      System
+      |> expect(:cmd, fn "mix", _args, _opts -> {report([issue(%{})]), 1} end)
+      |> expect(:cmd, fn "mix", _args, _opts ->
+        {report([
+           issue(%{
+             "check" => "Credo.Check.Warning.IoInspect",
+             "category" => "warning",
+             "filename" => "priv/repo/migrations/001_init.exs",
+             "line_no" => 3,
+             "message" => "There should be no calls to IO.inspect/2."
+           })
+         ]), 1}
+      end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.status == :error
+      assert result.stats.issue_count == 2
+      assert result.summary == "2 issues (1 warning, 1 readability)"
+
+      assert Enum.map(ExQuality.Stage.findings(result), & &1.file) == [
+               "lib/my_app/user.ex",
+               "priv/repo/migrations/001_init.exs"
+             ]
+    end
+
+    test "counts an issue both configs report once" do
+      System
+      |> expect(:cmd, 2, fn "mix", _args, _opts -> {report([issue(%{})]), 1} end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.stats.issue_count == 1
+      assert result.summary == "1 issue (1 readability)"
+      assert [%{file: "lib/my_app/user.ex"}] = ExQuality.Stage.findings(result)
+    end
+
+    test "keeps two issues that differ only in check" do
+      System
+      |> expect(:cmd, fn "mix", _args, _opts -> {report([issue(%{})]), 1} end)
+      |> expect(:cmd, fn "mix", _args, _opts ->
+        {report([issue(%{"check" => "Credo.Check.Readability.Specs"})]), 1}
+      end)
+
+      assert Credo.run(credo: [configs: ["a", "b"]]).stats.issue_count == 2
+    end
+
+    test "names the config when a run reported no issues and failed anyway" do
+      System
+      |> expect(:cmd, fn "mix", _args, _opts -> {report([]), 0} end)
+      |> expect(:cmd, fn "mix", _args, _opts -> {report([]), 1} end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.status == :error
+      assert result.summary == "Check failed in \"migrations\" (see output)"
+    end
+
+    test "names the config when a run printed no report at all" do
+      System
+      |> expect(:cmd, fn "mix", _args, _opts -> {report([]), 0} end)
+      |> expect(:cmd, fn "mix", _args, _opts ->
+        {"** (Mix) Unknown config: migrations\n", 1}
+      end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.status == :error
+      assert result.summary == ~s(Credo did not produce a report in "migrations")
+      assert result.output =~ "Unknown config: migrations"
+    end
+
+    test "attributes each run's output to the config that produced it" do
+      System
+      |> expect(:cmd, fn "mix", _args, _opts -> {"first\n", 0} end)
+      |> expect(:cmd, fn "mix", _args, _opts -> {"second\n", 0} end)
+
+      result = Credo.run(credo: [configs: ["default", "migrations"]])
+
+      assert result.output =~ "── credo --config-name default ──\nfirst"
+      assert result.output =~ "── credo --config-name migrations ──\nsecond"
+    end
+
+    test "an empty list runs credo once, as no list does" do
+      System
+      |> expect(:cmd, fn "mix", @args, _opts -> {report([]), 0} end)
+
+      assert Credo.run(credo: [configs: []]).status == :ok
+    end
+
+    test "configs: nil passes the same args as today" do
+      System
+      |> expect(:cmd, fn "mix", @args, _opts -> {report([]), 0} end)
+
+      result = Credo.run(credo: [configs: nil])
+
+      assert result.status == :ok
+      assert result.output == report([])
+    end
+  end
+
   describe "run/1 - timing" do
     setup do
       System

--- a/test/integration/quality_test.exs
+++ b/test/integration/quality_test.exs
@@ -132,6 +132,34 @@ defmodule Integration.ExQualityTest do
       assert output =~ "Dialyzer: skipped (disabled in .quality.exs)"
       refute output =~ "✓ Dialyzer"
     end
+
+    test "runs the project's own stages and reports what they said" do
+      fixture_path = copy_fixture("with_config")
+
+      {_output, 0} = System.cmd("mix", ["deps.get"], cd: fixture_path, stderr_to_stdout: true)
+
+      {output, exit_code} = run_quality(fixture_path)
+
+      assert exit_code == 0, "Expected success. Output:\n#{output}"
+
+      # The command printed the finding contract, so its own summary is used.
+      assert output =~ "✓ House rules: No bare Logger calls"
+
+      # A prerequisite the run cannot know about is not a code problem.
+      assert output =~ "○ Prerequisite: skipped (nothing to check here)"
+    end
+
+    test "--skip reaches a custom stage, which has no --skip-<key> of its own" do
+      fixture_path = copy_fixture("with_config")
+
+      {_output, 0} = System.cmd("mix", ["deps.get"], cd: fixture_path, stderr_to_stdout: true)
+
+      {output, exit_code} = run_quality(fixture_path, ["--skip", "house_rules"])
+
+      assert exit_code == 0, "Expected success. Output:\n#{output}"
+      assert output =~ "○ House rules: skipped (--skip house_rules)"
+      refute output =~ "✓ House rules"
+    end
   end
 
   describe "umbrella fixture" do

--- a/test/mix/tasks/quality_test.exs
+++ b/test/mix/tasks/quality_test.exs
@@ -562,6 +562,219 @@ defmodule Mix.Tasks.QualityTest do
     end
   end
 
+  describe "custom stages" do
+    defmodule HouseRules do
+      @moduledoc false
+      def run(_config) do
+        %{
+          name: "House rules",
+          status: :ok,
+          output: "",
+          stats: %{},
+          summary: "Nothing to say",
+          duration_ms: 1
+        }
+      end
+    end
+
+    # Only the custom stages and the tests are of interest here, so every
+    # built-in analysis stage is off unless a test turns one back on.
+    @quiet [
+      credo: [enabled: false],
+      dialyzer: [enabled: false],
+      doctor: [enabled: false],
+      gettext: [enabled: false],
+      sobelow: [enabled: false],
+      dependencies: [enabled: false],
+      test: [coverage: false]
+    ]
+
+    defp with_custom(entries, extra \\ []) do
+      base = Keyword.merge([custom: entries] ++ @quiet, extra)
+
+      ExQuality.Config
+      |> stub(:load, fn opts ->
+        opts
+        |> Keyword.get_values(:skip)
+        |> Enum.reduce(base, fn key, config ->
+          Keyword.put(config, String.to_atom(key),
+            enabled: false,
+            disabled_by: {:cli, "--skip #{key}"}
+          )
+        end)
+      end)
+    end
+
+    defp stub_quiet_run(extra \\ fn _cmd, _args, _opts -> nil end) do
+      System
+      |> stub(:cmd, fn cmd, args, opts ->
+        case extra.(cmd, args, opts) do
+          nil -> quiet_cmd(cmd, args)
+          result -> result
+        end
+      end)
+    end
+
+    defp quiet_cmd("mix", ["test" | _]), do: {"1 tests, 0 failures\n", 0}
+    defp quiet_cmd(_cmd, _args), do: {"", 0}
+
+    test "a command stage runs and reports its findings" do
+      path = Path.join(System.tmp_dir!(), "quality-#{System.unique_integer([:positive])}.json")
+      on_exit(fn -> File.rm(path) end)
+
+      document =
+        Jason.encode!(%{
+          "summary" => "1 unsound claim",
+          "findings" => [
+            %{
+              "file" => "lib/my_app/contact.ex",
+              "line" => 14,
+              "severity" => "error",
+              "check" => "unsound",
+              "message" => "field :email is typed non-nil but the column is nullable"
+            }
+          ]
+        })
+
+      with_custom([
+        [
+          key: :nullability,
+          name: "Nullability",
+          command: "mix",
+          args: ["schema.nullability", "--format", "json"]
+        ]
+      ])
+
+      stub_quiet_run(fn
+        "mix", ["schema.nullability" | _], _opts -> {document, 1}
+        _cmd, _args, _opts -> nil
+      end)
+
+      captured = capture_io(fn -> run_failing(["--report", path]) end)
+
+      assert captured =~
+               "lib/my_app/contact.ex\n  14  [error] field :email is typed non-nil " <>
+                 "but the column is nullable (unsound)"
+
+      report = path |> File.read!() |> Jason.decode!()
+      stage = Enum.find(report["stages"], &(&1["name"] == "Nullability"))
+
+      assert stage["status"] == "error"
+      assert stage["summary"] == "1 unsound claim"
+      assert [%{"file" => "lib/my_app/contact.ex", "check" => "unsound"}] = stage["findings"]
+    end
+
+    test "a module stage runs" do
+      with_custom([[key: :house_rules, name: "House rules", module: HouseRules]])
+      stub_quiet_run()
+
+      assert capture_io(fn -> Quality.run([]) end) =~ "✓ House rules: Nothing to say"
+    end
+
+    test "a custom stage appears in the JSON report like any other" do
+      path = Path.join(System.tmp_dir!(), "quality-#{System.unique_integer([:positive])}.json")
+      on_exit(fn -> File.rm(path) end)
+
+      with_custom([[key: :house_rules, name: "House rules", module: HouseRules]])
+      stub_quiet_run()
+
+      capture_io(fn -> Quality.run(["--report", path]) end)
+
+      report = path |> File.read!() |> Jason.decode!()
+      stage = Enum.find(report["stages"], &(&1["name"] == "House rules"))
+
+      assert stage["status"] == "ok"
+      assert stage["summary"] == "Nothing to say"
+    end
+
+    test "--skip names a custom stage, which has no --skip-<key> of its own" do
+      with_custom([[key: :nullability, name: "Nullability", command: "mix"]])
+      stub_quiet_run()
+
+      captured = capture_io(fn -> Quality.run(["--skip", "nullability"]) end)
+
+      assert captured =~ "○ Nullability: skipped (--skip nullability)"
+      refute captured =~ "✓ Nullability"
+    end
+
+    test "--skip works for a built-in stage too" do
+      with_custom([], credo: [enabled: true, available: true])
+      stub_quiet_run()
+
+      captured = capture_io(fn -> Quality.run(["--skip", "credo"]) end)
+
+      assert captured =~ "○ Credo: skipped (--skip credo)"
+    end
+
+    test "enabled: false in the entry skips it and names the file" do
+      with_custom([[key: :nullability, name: "Nullability", command: "mix", enabled: false]])
+      stub_quiet_run()
+
+      captured = capture_io(fn -> Quality.run([]) end)
+
+      assert captured =~ "○ Nullability: skipped (disabled in .quality.exs)"
+    end
+
+    test "a custom writer finishes before any reader starts" do
+      with_custom([
+        [key: :codegen, name: "Codegen", command: "mix", args: ["gen.all"], kind: :writer]
+      ])
+
+      test_pid = self()
+
+      stub_quiet_run(fn
+        "mix", ["gen.all"], _opts ->
+          send(test_pid, {:cmd, :codegen_started})
+          Process.sleep(50)
+          send(test_pid, {:cmd, :codegen_finished})
+          {"", 0}
+
+        "mix", ["test" | _], _opts ->
+          send(test_pid, {:cmd, :test_started})
+          {"1 tests, 0 failures\n", 0}
+
+        _cmd, _args, _opts ->
+          nil
+      end)
+
+      capture_io(fn -> Quality.run([]) end)
+
+      events = drain_events()
+
+      assert :test_started in events
+      assert Enum.take_while(events, &(&1 != :codegen_finished)) == [:codegen_started]
+    end
+
+    test "a custom stage survives a failed compile as skipped, with the compile's reason" do
+      with_custom([[key: :nullability, name: "Nullability", command: "mix"]])
+
+      stub_quiet_run(fn
+        "mix", ["compile" | _], _opts -> {"** (CompileError) boom\n", 1}
+        _cmd, _args, _opts -> nil
+      end)
+
+      captured = capture_io(fn -> run_failing([]) end)
+
+      assert captured =~ "○ Nullability: skipped (compile failed)"
+    end
+
+    test "a command that is not applicable is reported as skipped, not failed" do
+      with_custom([
+        [key: :nullability, name: "Nullability", command: "mix", skip_exit_code: 2]
+      ])
+
+      stub_quiet_run(fn
+        "mix", [], _opts -> {"test database is not migrated\n", 2}
+        _cmd, _args, _opts -> nil
+      end)
+
+      captured = capture_io(fn -> Quality.run([]) end)
+
+      assert captured =~ "○ Nullability: skipped (test database is not migrated)"
+      assert captured =~ "All quality checks passed"
+    end
+  end
+
   # The runs above fail on purpose; the report is the thing under test, not
   # the exception Mix raises afterwards.
   defp run_failing(args) do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -75,6 +75,7 @@ underlying tool to get detail that is already on screen.
 | Doctor | documentation coverage below the project's threshold | writing the missing `@moduledoc`/`@doc` |
 | Gettext | missing or fuzzy translations | translating them, or resolving the fuzzy entries |
 | any stage | `mix <task> is aliased in mix.exs` | renaming the alias, see below |
+| a custom stage | whatever the project's own check reports | fixing it at `file:line`; the check is the project's, so ask before changing what it enforces |
 | Sobelow | a security finding at or above the blocking threshold | fixing it at `file:line` |
 | Tests | a test failure, or modules under the coverage threshold | fixing the code, or writing tests for the named modules |
 
@@ -105,8 +106,14 @@ a red run because it removes the signal:
   `test_coverage`, and changing it is a decision for a human.
 - **Do not edit `.sobelow-conf`** to add an `ignore` or lower `exit:`. Silencing
   a security finding is a security decision, not a fix.
-- **Do not add `--skip-*` flags, or `enabled: false` in `.quality.exs`**, to get
-  past a failing stage.
+- **Do not add `--skip-*` or `--skip <key>` flags, or `enabled: false` in
+  `.quality.exs`**, to get past a failing stage.
+- **Do not convert a failing check into a custom stage in order to skip it.**
+  Moving a check somewhere it can be turned off is not fixing it.
+- **Do not use a custom stage to re-run a built-in tool with different flags.**
+  Its output comes back as text instead of per-check findings, which is the
+  routing the JSON report exists for. If a built-in stage cannot express
+  something its tool supports, that is a bug in the stage - report it.
 - **Do not delete, skip, or `@tag :skip` a failing test** to make the suite
   pass.
 - **Do not weaken a check** (`credo: [strict: false]`,
@@ -148,6 +155,9 @@ Every stage carries the same keys whatever its status:
 A skipped stage puts its reason in `summary`. A stage that failed without
 parseable findings carries its tool's output under `output` instead; for a
 failure, one of the two is always present.
+
+A project can add stages of its own, so `name` is not one of a fixed set. Route
+on `status` and `findings`; treat `name` as a label.
 
 ## Configuration
 


### PR DESCRIPTION
Two independent additions. They can be reviewed separately; the first is a correctness gap, the second is the larger design.

## Multiple Credo configs

A `.credo.exs` can declare a second config, and a check that lives in it does not run under the default one. That is the usual shape for migrations: they sit outside credo's default `files.included`, and folding them in would subject every migration to the whole default check set.

`ExQuality.Stages.Credo` built its args from `strict` and `all` and nothing else, so it always invoked `mix credo` once with no `--config-name`. The second config's check silently stopped running — the same failure mode as an aliased mix task: a check the project believes is enforced, is not.

```elixir
credo: [configs: ["default", "migrations"]]
```

One invocation per name, in order, merged into one stage result.

- **Serial, not concurrent.** `mix credo` runs with `MIX_ENV=dev` and can compile, and two concurrent mix runs against the same `_build` is the hazard the reader/writer split already exists to avoid. The stage as a whole still runs in parallel with every other analysis stage.
- **Findings deduplicate** on `{file, line, column, check}`. Two configs with overlapping `files` globs report the same issue twice, and a doubled count is worse than a missed one because it is not obviously wrong.
- **A failure names its config** (`Check failed in "migrations" (see output)`), because the likeliest cause is a name `.credo.exs` does not define, and the old summary gave a reader nothing to go on.
- `configs: nil` produces byte-identical args and output to today, which the tests pin.

## Custom stages

A project with a house check, a schema linter, a custom mix task or a shell script gate could have ex_quality's parallelism, timing, report and printer, or it could have its own check, but not both. Those checks lived outside the run and outside the JSON report, which means nothing that routes findings to fixers could see them.

Two layers, one mechanism:

```elixir
custom: [
  # A command. This is the case most projects want.
  [
    key: :nullability,
    name: "Nullability",
    command: "mix",
    args: ["schema.nullability", "--format", "json"],
    env: [{"MIX_ENV", "test"}],
    kind: :reader
  ],

  # A module, for anything the command form cannot express.
  [key: :house_rules, name: "House rules", module: MyApp.Quality.HouseRules]
]
```

Registration data lives in the entry rather than in callbacks on a module, so the config file alone says what a run will contain — a stage that only announces itself once it has run cannot be reported as skipped.

**The finding contract.** A command prints one JSON document on stdout (`summary`, `stats`, `findings`). Only `file` and `message` are required per finding; `app` is inferred from the path. Anything that does not parse falls through to `output` verbatim, which is the rule the printer and the report already follow. `parse: :none` opts out for a command known to print prose.

**`skip_exit_code`.** A custom check often has a prerequisite ex_quality cannot know about — a migrated test database, a running service. Without a way to say "not applicable" the stage fails with an error that reads like a code problem. The command exits with the declared code and the stage reports `:skipped` with the command's own reason, keeping the invariant that a stage saying nothing would read as a stage that passed.

**Validation.** A malformed entry fails the run at load time and names itself: missing `key`/`name`, neither or both of `module`/`command`, a key or name colliding with a built-in, a duplicate key, a bad `kind`/`parse`/`skip_exit_code`, a module that is not loadable or does not export `run/1`. A stage that never registers is a check nobody is told is not running.

**`--skip <key>`** skips any stage by key, built-in or custom, and is repeatable. `@switches` is static, so a custom stage could never have a `--skip-<key>` generated for it. The existing `--skip-credo` and friends are unchanged, and each spelling reports itself as the reason.

## Notes for review

Two deviations from the design doc:

1. The doc said `skip_reason/2` should report `--skip <key>` "for either spelling". I kept `--skip-credo` reporting itself — naming a switch the user did not type is a small lie, and there are docs and tests pinned to the current text.
2. The analysis stage tuples `{key, module, name}` became maps carrying `key`, `name`, `kind`, a runner and a skip reason. `Stage.kind/2` cannot express a command entry's `kind:`, and `Command.run/1` needs its own entry, so a shared shape was cleaner than dispatching on arity. Everything downstream is unchanged.

One thing that leaks into the public contract: a custom command's `stats` are carried string-keyed, because the names come from a config file and atomising arbitrary ones is unbounded. So `ExQuality.Stage.stats()` gained an `optional(String.t())` member, and `docs/reports.md` now says a report consumer cannot assume a stage `name` is one of nine, or that stats keys are drawn from the built-in set.

Also adds `ExQuality.Finding.from_map/2` — the reading half of the report's finding encoding. It is what a command's output is decoded with, and what a consumer of a report needs in order to read one back.

## Verification

`mix quality` is green. 446 unit tests and 15 integration tests, 0 failures.

The `with_config` fixture gained two real custom stages — a command printing the finding contract, and one exiting with `skip_exit_code` — so the whole path is exercised against real subprocesses rather than only against mocks.

No version bump; that is left to a release commit.