### PR TITLE
Adds compile force option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`compile: [force: true]`** compiles dev and test with `--force`, so a local run matches the cold build CI does. The usual argument for `--force` - that a warm build hides warnings - is obsolete, since Elixir re-emits persisted diagnostics for unchanged files. One class does survive: remove a public function and its callers are not recompiled, because a remote call is not a compile-time dependency, so nothing warns locally and CI fails. Off by default, since it costs a full recompile of the project's own apps on every run and is redundant in CI. The success summary names it (`dev + test compiled (forced, warnings as errors)`), and a forced run that passes stays as quiet as an incremental one
+
 ## [0.9.0] - 2026-08-01
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,8 @@ A keyword list at the project root. Every key is optional.
   quick: false,
 
   compile: [
-    warnings_as_errors: true
+    warnings_as_errors: true,
+    force: false
   ],
 
   credo: [

--- a/docs/stages.md
+++ b/docs/stages.md
@@ -36,6 +36,17 @@ as stages that passed.
 
 Set `compile: [warnings_as_errors: false]` to allow warnings.
 
+Set `compile: [force: true]` to compile with `--force`, so the local run matches
+the cold build CI does. An incremental build misses a whole class of breakage:
+remove a public function and its callers are not recompiled, because a remote
+call is not a compile-time dependency, so nothing warns locally and CI fails.
+The cost is a full recompile of the project's own apps on every run, which is
+why it is off by default and why it is worth turning on for a pre-push gate.
+
+```
+✓ Compile: dev + test compiled (forced, warnings as errors) (12.1s)
+```
+
 ## Credo
 
 Runs `mix credo --format json`, so an issue is never dropped for having an

--- a/lib/ex_quality/config.ex
+++ b/lib/ex_quality/config.ex
@@ -42,6 +42,7 @@ defmodule ExQuality.Config do
 
   Stage-specific options:
   - `compile.warnings_as_errors` - Treat warnings as errors (default: true)
+  - `compile.force` - Recompile from scratch (default: false)
   - `credo.strict` - Use strict mode (default: true)
   - `credo.all` - Check all files (default: false)
   - `credo.configs` - Names of the `.credo.exs` configs to run, in order
@@ -68,7 +69,8 @@ defmodule ExQuality.Config do
 
     # Stage-specific options
     compile: [
-      warnings_as_errors: true
+      warnings_as_errors: true,
+      force: false
     ],
     credo: [
       enabled: :auto,

--- a/lib/ex_quality/stages/compile.ex
+++ b/lib/ex_quality/stages/compile.ex
@@ -4,7 +4,8 @@ defmodule ExQuality.Stages.Compile do
 
   Runs `mix compile --warnings-as-errors` in parallel for both
   MIX_ENV=dev and MIX_ENV=test. Both compilations must succeed
-  for the stage to pass.
+  for the stage to pass. `compile: [force: true]` adds `--force`,
+  so the run matches the cold build CI does.
 
   - dev environment is needed for credo, dialyzer, doctor, and gettext
   - test environment is needed for running tests
@@ -20,14 +21,13 @@ defmodule ExQuality.Stages.Compile do
   def run(config) do
     start_time = System.monotonic_time(:millisecond)
 
-    warnings_as_errors =
-      config
-      |> Keyword.get(:compile, [])
-      |> Keyword.get(:warnings_as_errors, true)
+    compile_config = Keyword.get(config, :compile, [])
+    warnings_as_errors = Keyword.get(compile_config, :warnings_as_errors, true)
+    force = Keyword.get(compile_config, :force, false)
 
     # Run both compilations in parallel
-    dev_task = Task.async(fn -> compile_env("dev", warnings_as_errors) end)
-    test_task = Task.async(fn -> compile_env("test", warnings_as_errors) end)
+    dev_task = Task.async(fn -> compile_env("dev", warnings_as_errors, force) end)
+    test_task = Task.async(fn -> compile_env("test", warnings_as_errors, force) end)
 
     dev_result = Task.await(dev_task, :infinity)
     test_result = Task.await(test_task, :infinity)
@@ -36,14 +36,12 @@ defmodule ExQuality.Stages.Compile do
 
     case {dev_result, test_result} do
       {{:ok, dev_output}, {:ok, test_output}} ->
-        warnings_note = if warnings_as_errors, do: " (warnings as errors)", else: ""
-
         %{
           name: "Compile",
           status: :ok,
           output: format_success_output(dev_output, test_output),
           stats: %{},
-          summary: "dev + test compiled#{warnings_note}",
+          summary: "dev + test compiled#{notes(force, warnings_as_errors)}",
           duration_ms: duration_ms
         }
 
@@ -69,13 +67,23 @@ defmodule ExQuality.Stages.Compile do
     end
   end
 
-  defp compile_env(env, warnings_as_errors) do
+  defp notes(force, warnings_as_errors) do
+    enabled =
+      [{force, "forced"}, {warnings_as_errors, "warnings as errors"}]
+      |> Enum.filter(fn {on?, _note} -> on? end)
+      |> Enum.map(fn {_on?, note} -> note end)
+
+    case enabled do
+      [] -> ""
+      notes -> " (#{Enum.join(notes, ", ")})"
+    end
+  end
+
+  defp compile_env(env, warnings_as_errors, force) do
     args =
-      if warnings_as_errors do
-        ["compile", "--warnings-as-errors"]
-      else
-        ["compile"]
-      end
+      ["compile"] ++
+        if(warnings_as_errors, do: ["--warnings-as-errors"], else: []) ++
+        if(force, do: ["--force"], else: [])
 
     {output, exit_code} =
       System.cmd("mix", args,

--- a/lib/mix/tasks/quality/init.ex
+++ b/lib/mix/tasks/quality/init.ex
@@ -275,7 +275,8 @@ defmodule Mix.Tasks.Quality.Init do
 
       # Compilation options
       # compile: [
-      #   warnings_as_errors: true
+      #   warnings_as_errors: true,
+      #   force: false  # Recompile from scratch, like CI does
       # ],
 
       # Credo static analysis

--- a/test/ex_quality/config_test.exs
+++ b/test/ex_quality/config_test.exs
@@ -277,6 +277,12 @@ defmodule ExQuality.ConfigTest do
 
       assert config[:compile][:warnings_as_errors] == true
     end
+
+    test "compile force defaults to false" do
+      config = Config.load()
+
+      assert config[:compile][:force] == false
+    end
   end
 
   defp write_config(tmp_dir, path) do

--- a/test/ex_quality/stages/compile_test.exs
+++ b/test/ex_quality/stages/compile_test.exs
@@ -17,12 +17,17 @@ defmodule ExQuality.Stages.CompileTest do
         Generated my_app app
         """
 
-        case {args, mix_env} do
-          {["compile", "--warnings-as-errors"], "dev"} -> {output, 0}
-          {["compile", "--warnings-as-errors"], "test"} -> {output, 0}
-          {["compile"], "dev"} -> {output, 0}
-          {["compile"], "test"} -> {output, 0}
-          _ -> {"Unexpected command", 1}
+        known_args = [
+          ["compile"],
+          ["compile", "--warnings-as-errors"],
+          ["compile", "--force"],
+          ["compile", "--warnings-as-errors", "--force"]
+        ]
+
+        if mix_env in ["dev", "test"] and args in known_args do
+          {output, 0}
+        else
+          {"Unexpected command", 1}
         end
       end)
 
@@ -63,6 +68,64 @@ defmodule ExQuality.Stages.CompileTest do
       assert result.status == :ok
       refute result.summary =~ "warnings as errors"
       assert result.summary =~ "dev + test compiled"
+    end
+
+    test "omits forced note by default" do
+      result = Compile.run([])
+
+      refute result.summary =~ "forced"
+    end
+
+    test "notes both settings when force and warnings_as_errors are on" do
+      config = [compile: [warnings_as_errors: true, force: true]]
+      result = Compile.run(config)
+
+      assert result.status == :ok
+      assert result.summary == "dev + test compiled (forced, warnings as errors)"
+    end
+
+    test "notes force alone when warnings_as_errors is false" do
+      config = [compile: [warnings_as_errors: false, force: true]]
+      result = Compile.run(config)
+
+      assert result.status == :ok
+      assert result.summary == "dev + test compiled (forced)"
+    end
+
+    test "a forced run that succeeds stays quiet" do
+      config = [compile: [force: true]]
+      result = Compile.run(config)
+
+      # `--force` always prints "Compiling N files (.ex)", which is boring
+      assert result.output == ""
+    end
+  end
+
+  describe "run/1 - force config" do
+    setup do
+      # Only the forced args succeed, so a dropped --force fails the stage
+      System
+      |> stub(:cmd, fn "mix", args, _opts ->
+        case args do
+          ["compile", "--warnings-as-errors", "--force"] -> {"Compiling 15 files (.ex)\n", 0}
+          _ -> {"Unexpected command: #{Enum.join(args, " ")}", 1}
+        end
+      end)
+
+      :ok
+    end
+
+    test "passes --force when force is true" do
+      result = Compile.run(compile: [force: true])
+
+      assert result.status == :ok
+    end
+
+    test "omits --force by default" do
+      result = Compile.run([])
+
+      assert result.status == :error
+      assert result.output =~ "Unexpected command: compile --warnings-as-errors"
     end
   end
 


### PR DESCRIPTION
Adds `compile: [force: true]`, which compiles dev and test with `--force` so a
local run matches the cold build CI does. Default `false`, which is exactly
today's behavior.

## Why

A project whose pre-`mix quality` wrapper script ran `mix compile
--warnings-as-errors --force` silently lost the `--force` on adopting the
stage - its narrow per-file entry point ended up stricter than the full run,
which is the wrong way round for a gate.

The usual argument for `--force` turns out to be wrong. The folklore is that a
warm build hides warnings, but Elixir persists compiler diagnostics and
re-emits them for unchanged files, so a second `mix compile
--warnings-as-errors` over an untouched tree still fails. For that case the
stage is already correct and `--force` would only cost time.

One class does survive, and it is the CI-divergence class. Remove a public
function while its caller stays untouched: Mix does not mark the caller stale,
since a remote call is not a compile-time dependency, so nothing is recompiled
and nothing warns. `--force` reports `B.foo/0 is undefined or private`. That is
the failure that passes locally and breaks CI, which is exactly what a pre-push
gate exists to catch.

Cost, measured on a 10-app umbrella: ~1s warm against 10-15s forced (dev and
test compile concurrently). Real, but small next to any run including a test
suite or dialyzer, which is every run this would be enabled for. It is opt-in
because it costs that on every run and is redundant in CI, where the build is
already cold.

## Changes

- `ExQuality.Stages.Compile` reads `config[:compile][:force]` and appends
  `--force` to both env compilations
- The success suffix was a single `warnings_note`; two independent flags would
  leave it reading badly, so it is now a list of enabled notes joined with
  `", "` - `dev + test compiled (forced, warnings as errors)` - and no
  combination leaves an empty paren
- A forced run always prints `Compiling N files (.ex)`, which the existing
  output filter already drops, so a passing forced run stays as quiet as a warm
  one. Pinned by a test, since that is the difference between the option being
  invisible and it adding a paragraph to every passing run
- Docs and config: `config.ex` defaults and moduledoc, `mix quality.init`
  scaffold, `docs/configuration.md`, and `docs/stages.md` with the *why*

No `usage-rules.md` entry: its prohibitions are about not weakening checks, and
`force` only ever strengthens one. Turning it off to dodge a failure is already
covered by the general rule.

## Testing

- Arg-building tests with a stub that accepts only the forced args, so a
  dropped `--force` fails the stage, plus the reverse for the default
- Summary tests for both flags on, force alone, and force off
- A default-value test in `config_test.exs`
- 453 tests pass; full `mix quality` green