### PR TITLE
Fixes two custom-stage papercuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A skipped custom stage's reason is no longer whatever the toolchain printed first.** The reason a person reads was the command's first non-empty line, which made it hostage to output the command did not write: `mix` emits `==> app` headers for an umbrella and a build-lock notice when another stage holds the lock, either of which turned `skipped (the database has no tables - run bin/test-setup)` into `skipped (==> admin)`. That defeats the point of `skip_exit_code:`, which exists to turn a confusing failure into a reason somebody can act on. The document's `summary` is now preferred when the command wrote one, falling back to the first line for a command that prints prose or sets `parse: :none`
+- **A custom stage's `command:` may name a project's own script.** `System.cmd/3` resolves a bare name on the PATH and otherwise wants an absolute path - even `./bin/check.sh` raises `:enoent` - so a repo-relative script, which is the ordinary case for a custom stage, had to be written as `command: "bash", args: ["bin/check.sh"]`. A command containing `/` is now expanded before it runs, relative to `cd:` when the entry names one and to the project root otherwise, so an entry reads as the shell it looks like. A bare name still goes to the PATH and an absolute path is used as it stands
+
 ## [0.10.0] - 2026-08-01
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,6 +182,17 @@ Exit code 0 is a pass, anything else is a failure. The command runs with
 `stderr_to_stdout: true`. The JSON finding contract, and the reader/writer
 warning, are in [stages.md](stages.md#custom-stages).
 
+A bare `command` is looked up on the PATH. One containing `/` is a path and is
+expanded before it runs, so a project's own script can be named directly:
+
+```elixir
+[key: :schema, name: "Schema", command: "bin/checks/schema.sh"]
+```
+
+It is relative to `cd` when the entry names one and to the project root
+otherwise, so the entry reads as the shell it looks like: `cd <cd> && <command>
+<args>`. An absolute path is used as it stands.
+
 ### Validation
 
 A malformed entry fails the run at load time and names itself, because a stage

--- a/docs/stages.md
+++ b/docs/stages.md
@@ -218,10 +218,10 @@ JSON document on stdout:
   "stats": {"finding_count": 2},
   "findings": [
     {
-      "file": "apps/walt_ui/lib/walt_ui/contacts/contact.ex",
+      "file": "apps/web/lib/web/contacts/contact.ex",
       "line": 14,
       "column": null,
-      "app": "walt_ui",
+      "app": "web",
       "severity": "error",
       "check": "unsound",
       "message": "field :email is typed non-nil but the column is nullable"
@@ -246,7 +246,7 @@ test database, a running service, a generated file. Without a way to say "not
 applicable" the stage fails with an error that reads like a code problem.
 
 `skip_exit_code: 2` lets the command exit 2 and have the stage report itself as
-skipped, with the command's own first line as the reason:
+skipped, with its own reason:
 
 ```
 ○ Nullability: skipped (test database is not migrated)
@@ -254,6 +254,17 @@ skipped, with the command's own first line as the reason:
 
 Which keeps the invariant a run depends on: a stage that says nothing would
 read as a stage that passed.
+
+The reason is the document's `summary` when the command wrote one, and the
+first line of output otherwise. **Write the summary.** A first line is hostage
+to whatever the toolchain prints ahead of the command's own output, and `mix`
+is the common offender: it emits `==> app` headers for an umbrella, and a
+build-lock notice when another stage holds the lock. Either turns a reason
+somebody can act on into one they cannot:
+
+```
+○ Nullability: skipped (==> admin)
+```
 
 ## Aliased tasks
 

--- a/lib/ex_quality/stages/command.ex
+++ b/lib/ex_quality/stages/command.ex
@@ -23,6 +23,17 @@ defmodule ExQuality.Stages.Command do
   `stderr_to_stdout: true`, as every other shelling stage is, so a tool that
   writes its complaint to stderr is not thrown away.
 
+  ## Naming the command
+
+  A bare name is looked up on the PATH. A command containing `/` is a path, and
+  is expanded before it runs, so a project's own script can be named directly:
+
+      command: "bin/checks/schema.sh"
+
+  The path is relative to `cd:` when one is given and to the project root
+  otherwise, so an entry reads as the shell it looks like: `cd <cd> &&
+  <command> <args>`. An absolute path is used as it stands.
+
   ## The finding contract
 
   A command that wants structured findings prints one JSON document on stdout:
@@ -35,7 +46,7 @@ defmodule ExQuality.Stages.Command do
             "file": "lib/contacts/contact.ex",
             "line": 14,
             "column": null,
-            "app": "walt_ui",
+            "app": "web",
             "severity": "error",
             "check": "unsound",
             "message": "field :email is typed non-nil but the column is nullable"
@@ -57,9 +68,14 @@ defmodule ExQuality.Stages.Command do
   migrated test database, a running service, a generated file. Without a way to
   say "not applicable" the stage fails with an error that reads like a code
   problem. `skip_exit_code: 2` lets the command exit 2 and have the stage
-  report `:skipped` with the command's own first line as the reason, which
-  keeps the invariant that a stage saying nothing would read as a stage that
-  passed.
+  report `:skipped` with its own reason, which keeps the invariant that a stage
+  saying nothing would read as a stage that passed.
+
+  The reason is the document's `summary` when the command wrote one, and the
+  first line of output otherwise. Prefer the document: a first line is hostage
+  to whatever the toolchain prints ahead of the command's own output, and `mix`
+  in particular emits `==> app` headers for an umbrella and a build-lock notice
+  when another stage holds the lock.
 
   ## Reader versus writer
 
@@ -89,7 +105,7 @@ defmodule ExQuality.Stages.Command do
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(entry) do
     name = Keyword.fetch!(entry, :name)
-    command = Keyword.fetch!(entry, :command)
+    command = resolve(Keyword.fetch!(entry, :command), Keyword.get(entry, :cd))
     start_time = System.monotonic_time(:millisecond)
 
     outcome = execute(command, Keyword.get(entry, :args, []), cmd_opts(entry))
@@ -99,6 +115,23 @@ defmodule ExQuality.Stages.Command do
     case outcome do
       {:ok, output, exit_code} -> result(entry, name, output, exit_code, duration_ms)
       {:error, reason} -> unrunnable(name, command, reason, duration_ms)
+    end
+  end
+
+  # `System.cmd/3` resolves a bare name on the PATH and otherwise wants an
+  # absolute path: even `./bin/check.sh` raises `:enoent`, because nothing
+  # expands it. A repo's own script is the ordinary case for a custom stage, so
+  # a command carrying a path separator is expanded here rather than left to
+  # be written as `command: "bash", args: ["bin/check.sh"]`.
+  #
+  # Relative to `cd:` when one is given, so an entry reads as the shell it
+  # looks like: `cd <cd> && <command> <args>`. An absolute command is returned
+  # unchanged, and a bare name still goes to the PATH.
+  defp resolve(command, cd) do
+    if String.contains?(command, "/") do
+      Path.expand(command, cd || File.cwd!())
+    else
+      command
     end
   end
 
@@ -139,7 +172,7 @@ defmodule ExQuality.Stages.Command do
         status: :skipped,
         output: output,
         stats: %{},
-        summary: skip_reason(output),
+        summary: skip_reason(entry, output),
         duration_ms: duration_ms
       }
     else
@@ -147,7 +180,23 @@ defmodule ExQuality.Stages.Command do
     end
   end
 
-  defp skip_reason(output) do
+  # A skipped stage's reason is the one line a person reads, so it is taken
+  # from the document's `summary` when the command wrote one. The first line of
+  # output is the fallback, and on its own it is hostage to whatever the
+  # toolchain prints first: `mix` emits `==> app` headers for an umbrella and a
+  # build-lock notice when another stage holds the lock, either of which turns
+  # a useful reason into noise.
+  defp skip_reason(entry, output) do
+    with %{"summary" => summary} <- document(entry, output),
+         true <- is_binary(summary),
+         trimmed when trimmed != "" <- String.trim(summary) do
+      trimmed
+    else
+      _no_summary -> first_line(output)
+    end
+  end
+
+  defp first_line(output) do
     output
     |> String.split("\n")
     |> Enum.map(&String.trim/1)

--- a/test/ex_quality/stages/command_test.exs
+++ b/test/ex_quality/stages/command_test.exs
@@ -50,6 +50,53 @@ defmodule ExQuality.Stages.CommandTest do
       assert Command.run(Keyword.put(@entry, :cd, "apps/web")).status == :ok
     end
 
+    test "leaves a bare command name for the PATH to resolve" do
+      System
+      |> expect(:cmd, fn command, _args, _opts ->
+        assert command == "mix"
+        {"", 0}
+      end)
+
+      assert Command.run(@entry).status == :ok
+    end
+
+    test "expands a command carrying a path separator against the project root" do
+      System
+      |> expect(:cmd, fn command, _args, _opts ->
+        assert command == Path.expand("bin/checks/schema.sh", File.cwd!())
+        assert Path.type(command) == :absolute
+        {"", 0}
+      end)
+
+      entry = Keyword.put(@entry, :command, "bin/checks/schema.sh")
+
+      assert Command.run(entry).status == :ok
+    end
+
+    test "expands a relative command against cd when the entry names one" do
+      System
+      |> expect(:cmd, fn command, _args, _opts ->
+        assert command == Path.expand("assets/bin/build.sh", File.cwd!())
+        {"", 0}
+      end)
+
+      entry = Keyword.merge(@entry, command: "bin/build.sh", cd: "assets")
+
+      assert Command.run(entry).status == :ok
+    end
+
+    test "leaves an absolute command as it stands" do
+      System
+      |> expect(:cmd, fn command, _args, _opts ->
+        assert command == "/usr/local/bin/check"
+        {"", 0}
+      end)
+
+      entry = Keyword.put(@entry, :command, "/usr/local/bin/check")
+
+      assert Command.run(entry).status == :ok
+    end
+
     test "reports a command that could not be run rather than crashing the run" do
       System
       |> expect(:cmd, fn _cmd, _args, _opts -> raise ErlangError, original: :enoent end)
@@ -197,6 +244,51 @@ defmodule ExQuality.Stages.CommandTest do
       assert result.status == :skipped
       assert result.summary == "test database is not migrated"
       assert result.output =~ "not migrated"
+    end
+
+    test "prefers the document's summary to the first line of output" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        output =
+          "==> web\n" <>
+            document(%{"summary" => "the database has no tables - run bin/test-setup"})
+
+        {output, 2}
+      end)
+
+      result = Command.run(Keyword.put(@entry, :skip_exit_code, 2))
+
+      assert result.status == :skipped
+      assert result.summary == "the database has no tables - run bin/test-setup"
+    end
+
+    test "falls back to the first line when the document has no summary" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {"not migrated\n" <> document(%{"findings" => []}), 2}
+      end)
+
+      assert Command.run(Keyword.put(@entry, :skip_exit_code, 2)).summary == "not migrated"
+    end
+
+    test "falls back to the first line when the summary is blank" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {"not migrated\n" <> document(%{"summary" => "   "}), 2}
+      end)
+
+      assert Command.run(Keyword.put(@entry, :skip_exit_code, 2)).summary == "not migrated"
+    end
+
+    test "falls back to the first line when parsing is off" do
+      System
+      |> expect(:cmd, fn _cmd, _args, _opts ->
+        {"not migrated\n" <> document(%{"summary" => "ignored"}), 2}
+      end)
+
+      entry = @entry |> Keyword.put(:skip_exit_code, 2) |> Keyword.put(:parse, :none)
+
+      assert Command.run(entry).summary == "not migrated"
     end
 
     test "says something even when the command exited quietly" do

--- a/test/ex_quality/stages/test_test.exs
+++ b/test/ex_quality/stages/test_test.exs
@@ -155,20 +155,20 @@ defmodule ExQuality.Stages.TestTest do
       |> stub(:available?, fn _tool -> false end)
 
       ExQuality.Umbrella
-      |> stub(:apps_paths, fn -> %{walt_ui: "apps/walt_ui"} end)
+      |> stub(:apps_paths, fn -> %{web: "apps/web"} end)
 
       System
       |> expect(:cmd, fn "mix", ["test"], _opts ->
         output = """
-        ==> walt_ui
+        ==> web
         .....F
 
-          1) test Oban jobs a job execution produces a consumer span (WaltUi.Telemetry.ConsumerTracingTest)
-             apps/walt_ui/test/walt_ui/telemetry/consumer_tracing_test.exs:118
+          1) test Oban jobs a job execution produces a consumer span (Web.Telemetry.ConsumerTracingTest)
+             apps/web/test/web/telemetry/consumer_tracing_test.exs:118
              expected an Oban job span named 'process default'
              code: assert job_span, "expected an Oban job span named 'process default'"
              stacktrace:
-               test/walt_ui/telemetry/consumer_tracing_test.exs:145: (test)
+               test/web/telemetry/consumer_tracing_test.exs:145: (test)
 
 
         Finished in 3.1 seconds
@@ -184,10 +184,10 @@ defmodule ExQuality.Stages.TestTest do
     test "attributes the failure to its app, from the header line's path" do
       assert [finding] = ExQuality.Stage.findings(Test.run([]))
 
-      assert finding.app == :walt_ui
-      assert finding.file == "apps/walt_ui/test/walt_ui/telemetry/consumer_tracing_test.exs"
+      assert finding.app == :web
+      assert finding.file == "apps/web/test/web/telemetry/consumer_tracing_test.exs"
       assert finding.line == 118
-      assert finding.check == "WaltUi.Telemetry.ConsumerTracingTest"
+      assert finding.check == "Web.Telemetry.ConsumerTracingTest"
     end
 
     test "reads the header line rather than the app-relative stacktrace" do
@@ -195,7 +195,7 @@ defmodule ExQuality.Stages.TestTest do
 
       # The stacktrace says test/... and line 145; only the header line opens
       # from the umbrella root.
-      refute finding.file == "test/walt_ui/telemetry/consumer_tracing_test.exs"
+      refute finding.file == "test/web/telemetry/consumer_tracing_test.exs"
       refute finding.line == 145
     end
 


### PR DESCRIPTION
Two papercuts found while registering a mix task as a custom stage. Both had the same shape: the mechanism worked, but the ergonomics pushed the caller into a workaround that then needed its own explanation.

## 1. A skipped stage's reason was whatever the toolchain printed first

`skip_exit_code:` exists to turn a confusing failure into a next step. But the reason shown was the command's **first non-empty line**, which made it hostage to output the command did not write:

```
○ Nullability: skipped (==> admin)                                  ← what you got
○ Nullability: skipped (database has no tables - run bin/test-setup) ← what the command said
```

`mix` emits `==> app` headers for an umbrella, and a build-lock notice when another stage holds the lock. Either one lands on that first line. The workaround downstream was a wrapper script whose only job was filtering the headers back out.

The document's `summary` is now preferred when the command wrote one, with the first line kept as the fallback for a command that prints prose or sets `parse: :none` — so nothing that worked before changes.

Worth noting `ExQuality.Json` already looks for a document rather than assuming the whole stream is one, so a header ahead of the JSON was never the obstacle. Only the skip path ignored it.

## 2. `command:` could not name a project's own script

`System.cmd/3` resolves a bare name on the PATH and otherwise wants an absolute path. Even `./bin/check.sh` raises `:enoent`, which is easy to assume otherwise — verified rather than guessed:

| `command` | result |
|---|---|
| `bin/probe.sh` | `RAISE :enoent` |
| `./bin/probe.sh` | `RAISE :enoent` |
| `probe.sh` | `RAISE :enoent` |
| `/abs/bin/probe.sh` | `OK` |

So naming a repo's own script — the ordinary case for a custom stage — meant `command: "bash", args: ["bin/check.sh"]` plus a comment explaining why.

A command containing `/` is now expanded before it runs, relative to `cd:` when the entry names one and to the project root otherwise, so an entry reads as the shell it looks like: `cd <cd> && <command> <args>`. A bare name still goes to the PATH; an absolute path is used as it stands.

## Verification

The mocks cannot show that `System.cmd/3` rejects a relative path in the first place, so both fixes were also exercised end to end against a real script that prints a mix-style header before its JSON and exits 2:

```
relative script + JSON summary   status: skipped  summary: the database has no tables - run bin/test-setup
same, parse: :none               status: skipped  summary: ==> some_app
```

The second line is the old behavior, still reachable on the documented fallback path — which is what confirms the first line is the new code doing the work.

`mix quality` green: 461 tests, 87.9% coverage, no credo or dialyzer findings.

## Also included

The finding-contract example in `docs/stages.md` and the `ExQuality.Stages.Command` moduledoc, plus the Test stage's umbrella fixture, had carried a downstream project's real app name since 0.9.0. Renamed to `web`, the neutral name the rest of the suite already uses. No behavior change.