### PR TITLE
Add an inner loop: scoped tests, profiles, stop-at-first-failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+An inner loop, beside the gate. Every flag this library had narrowed *stages*;
+what an agent iterating on one file needs is to narrow *scope*. A measured A/B of
+agentic development on a large umbrella lost both workloads against a control arm
+using individual check scripts, at 1.97x and 1.43x the wall clock, and the
+difference was not model time: it was seven `mix quality` runs averaging 61.7s, of
+which the test suite was 68%. Both arms could run one test file in 3s; only one of
+them had a reason to. `--quick` does not address this - it removes dialyzer and
+the coverage threshold and still runs every test, which against that split is 10%
+of the cost.
+
+### Added
+
+- **`test: [scope: :changed]`, or `--test-scope changed`, runs only the test files covering the code that changed.** Changed files are resolved against the merge base with the repository's default branch, including uncommitted and untracked work, because an agent mid-task has everything uncommitted and a diff that reads only committed history would report no changes on exactly the runs this exists for. `lib/foo/bar.ex` maps to `test/foo/bar_test.exs`, in an umbrella under the same app, and a changed test file is itself. `--test-scope` also takes `all` or a glob string, and `test: [base_ref: "origin/main"]` overrides what `:changed` is measured against
+- **A scope that resolves to no test files runs the full suite.** This is the one failure mode that would make the feature worse than not having it, because it fails in the safe-looking direction: exit 0, `"status": "ok"`, nothing run. The report says which happened, carrying the achieved `scope` with `requested_scope` and `fallback_reason` beside it, so a caller checking `scope == "all"` never has to reason about fallbacks
+- **Coverage on a scoped run is absent rather than lower.** It is reported as `"coverage": "skipped"` with a reason and never as a number: a percentage over a subset of the suite is not a smaller truth, it is a different and misleading one, and an adopting project that lowers a recorded figure on a green run would corrupt it against a run that never measured
+- **Profiles.** `profiles:` in `.quality.exs` names bundles of options, selected with `mix quality --profile loop`, so the fast path has a name a project's docs and its agent instructions can point at - a fast path nobody invokes is worth nothing. A profile's `stages:` key is an allow-list; every other stage, built-in or custom, is reported as skipped naming the profile. The profile merges over the config file and under the CLI. An unknown name fails the run, because falling back to "run everything" would turn a typo into a slow green
+- **`--until-first-failure`** runs one stage at a time, cheapest first, and stops at the first failure. An iterating caller does not need a full battery report, it needs the next thing to fix, and a run that pays for the suite before saying "you have a formatting error" is the opposite of that
+- **`test: [coverage: false]`** was already config-settable; profiles make it settable per profile, so a run can drop instrumentation while keeping dialyzer, which previously required taking all of `--quick`. Measured on a 3,700-test umbrella, warm build, 15 cores: 3.3s of 47s wall clock, but +46% user time, so the wall cost moves toward the CPU figure where cores are scarce
+- **`--report -`** writes the report to stdout, as `--format json` does. Agents were parsing human terminal text because a file path is one more step
+- **`profile`, `scope` and `base_ref` at the report root**, always present. `status` alone does not say what a run is evidence for: a green run over three test files and a green full run are different claims, and this is what lets anything that ratchets a number, moves a baseline or gates a merge refuse to move on the narrow one
+- The Tests stage reports `scope`, `files`, `test_files`, `base_ref` and the coverage keys above in its own object
+- `ExQuality.Scope`, which owns scope parsing and resolution
+- `ExQuality.Config.apply_profile/2` and `ExQuality.Config.profile/1`
+- A stage result may carry `meta`, a map of extra report fields describing what the stage did rather than what it found
+
+### Changed
+
+- Format, Compile and Tests can now be turned off by `--skip <key>` or by a profile's `stages:` list, and are reported as skipped with the reason like any other stage. They have never been skippable before, and an unprofiled run with no `--skip` still runs all three unconditionally
+- A run with no `--profile`, no `--test-scope` and no `--until-first-failure` behaves exactly as it did in 0.11.0. This is a 0.x library with real users, and the default path does not move
+
 ## [0.11.0] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,16 +81,35 @@ mix quality.init --skip-prompts
 `.quality.exs`. Nothing about it is required: ExQuality runs whatever the
 project already depends on.
 
-## Two modes
+## Three modes
 
 ```bash
-mix quality --quick    # while coding
-mix quality            # before committing, and in CI
+mix quality --test-scope changed   # between edits
+mix quality --quick                # while coding
+mix quality                        # before committing, and in CI
 ```
 
 Quick mode skips Dialyzer and coverage enforcement, the two slow stages. Tests
-still run, and everything else is unchanged. Full mode runs every enabled
-stage.
+still run, and everything else is unchanged. Full mode runs every enabled stage.
+
+`--test-scope changed` is the one that narrows the tests, which on a large suite
+is most of the wall clock. It runs only the test files covering the code you have
+changed, committed or not, and falls back to the whole suite if that maps to
+nothing: a green run of nothing is worse than a slow one. Coverage on a scoped run
+is reported as skipped rather than as a percentage over a subset.
+
+A project can name a bundle of those settings in `.quality.exs` so its docs and
+its agents point at one word:
+
+```elixir
+profiles: [loop: [stages: [:format, :compile, :credo], test: [scope: :changed]]]
+```
+
+```bash
+mix quality --profile loop
+```
+
+See [Configuration](docs/configuration.md#test-scope).
 
 ## Stages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,12 +5,13 @@ it decides on its own.
 
 ## Precedence
 
-Four sources, merged in order, later wins:
+Five sources, merged in order, later wins:
 
 1. **Defaults**
 2. **Auto-detection** - a stage is available when the project depends on its tool
 3. **`.quality.exs`** - read from the project root, not the working directory
-4. **CLI flags**
+4. **The profile** named by `--profile`, if any
+5. **CLI flags**
 
 Auto-detection only ever sets availability. A stage that is available can still
 be turned off by `.quality.exs` or a flag, and one that is unavailable can be
@@ -27,8 +28,12 @@ mix quality --skip-gettext        # skip translation checks
 mix quality --skip-sobelow        # skip security analysis
 mix quality --skip-dependencies   # skip unused deps and the security audit
 mix quality --skip KEY            # skip any stage by key; repeatable
+mix quality --profile NAME        # run a named bundle from .quality.exs
+mix quality --test-scope changed  # run only the tests covering changed code
+mix quality --until-first-failure # stop at the first failing stage, cheapest first
 mix quality --verbose             # print full output even for stages that passed
 mix quality --report PATH         # also write a JSON report to PATH
+mix quality --report -            # JSON report on stdout, human output on stderr
 mix quality --format json         # JSON report on stdout, human output on stderr
 ```
 
@@ -115,8 +120,15 @@ A keyword list at the project root. Every key is optional.
     # :auto measures coverage when the project's own config asks for it.
     coverage: :auto,
     # Extra arguments for mix test / mix coveralls.
-    args: []
-  ]
+    args: [],
+    # How much of the suite to run: :all, :changed, or a glob string.
+    scope: :all,
+    # What :changed is measured against. nil is the repository's default branch.
+    base_ref: nil
+  ],
+
+  # Named bundles of the options above, selected with --profile.
+  profiles: []
 ]
 ```
 
@@ -129,6 +141,87 @@ Every stage takes one of three values:
 | `:auto` | run when the tool is installed (the default) |
 | `true` | always run; errors if the tool is missing |
 | `false` | never run; reported as `○ Credo: skipped (disabled in .quality.exs)` |
+
+## Test scope
+
+Every flag above narrows *which checks run*. `scope` narrows *how much code they
+run over*, which is the expensive question: on a large suite the tests are most
+of a run's wall clock, and `--quick` does not touch them.
+
+```elixir
+test: [
+  scope: :changed,
+  base_ref: "origin/main"
+]
+```
+
+```bash
+mix quality --test-scope changed
+mix quality --test-scope all
+mix quality --test-scope "test/unit/**/*_test.exs"
+```
+
+| Value | Meaning |
+|---|---|
+| `:all` | the whole suite (the default) |
+| `:changed` | the test files covering the code changed against `base_ref` |
+| a glob string | the test files matching it |
+
+`:changed` reads the working tree, not just committed history, and folds in
+untracked files: work in progress is exactly what this is for.
+`lib/foo/bar.ex` maps to `test/foo/bar_test.exs`, and in an umbrella
+`apps/web/lib/user.ex` maps under `apps/web/test/`. A changed test file is
+itself.
+
+Two rules make a scoped green safe to read:
+
+- **A scope that resolves to no test files runs the whole suite.** A green run of
+  nothing is the one result that would be worse than a slow one, because it fails
+  in the safe-looking direction.
+- **Coverage on a scoped run is reported as `skipped`, never as a number.** A
+  percentage over a subset of the suite is not a smaller truth, it is a different
+  one, and anything that ratchets a recorded figure would lower it against a run
+  that never measured.
+
+The report says which of the two happened, at the root and on the Tests stage.
+See [Reports](reports.md).
+
+## Profiles
+
+A profile is a named bundle of the options above, so the fast path has a name a
+project's docs and its agent instructions can point at. A fast path nobody
+invokes is worth nothing.
+
+```elixir
+profiles: [
+  loop: [
+    stages: [:format, :compile, :credo],
+    test: [scope: :changed]
+  ],
+  gate: []
+]
+```
+
+```bash
+mix quality --profile loop
+```
+
+`stages:` is the allow-list for the profile. Every other stage, built-in or
+custom, is reported as skipped naming the profile:
+
+```
+○ Dialyzer: skipped (not in profile :loop)
+```
+
+A profile with no `stages:` key narrows nothing and only carries options, which
+is what an empty `gate: []` is for.
+
+- A run with no `--profile` behaves exactly as it did before profiles existed.
+- The profile merges over `.quality.exs` and under the CLI, so a flag still wins.
+- An unknown profile name **fails the run**. Falling back to "run everything"
+  would turn a typo into a slow green, and falling back to the profile's intent
+  would turn one into a fast green over nothing.
+- The profile name goes in the report, for the same reason the scope does.
 
 ## Custom stages
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -7,10 +7,13 @@ the tool.
 ```bash
 mix quality --report .quality.json   # human output on stdout, report to a file
 mix quality --format json            # report on stdout, human output on stderr
+mix quality --report -               # the same, spelled the way a pipe reads
 ```
 
-Both can be given at once. `--report` is usually the more useful of the two,
-because it leaves the human stream intact.
+Both of the first two can be given at once. `--report PATH` is usually the more
+useful, because it leaves the human stream intact. `--report -` is `--format
+json` under another name: the report takes stdout and the human output moves to
+stderr, rather than the two being interleaved into something nothing can parse.
 
 The report is built from the same results the human output is rendered from, so
 the two can never disagree.
@@ -22,6 +25,9 @@ the two can never disagree.
   "status": "error",
   "version": "0.6.0",
   "duration_ms": 5014,
+  "profile": "loop",
+  "scope": "changed",
+  "base_ref": "origin/main",
   "stages": []
 }
 ```
@@ -31,7 +37,21 @@ the two can never disagree.
 | `status` | `"ok"` \| `"error"` | `"error"` if any stage failed |
 | `version` | string | the ExQuality version that produced the report |
 | `duration_ms` | integer | wall clock time of the whole run, which is **not** the sum of the stage durations, because the analysis stages run in parallel |
+| `profile` | string \| null | the `--profile` the run used |
+| `scope` | string | how much of the suite ran: `"all"`, `"changed"`, or the glob |
+| `base_ref` | string \| null | what `"changed"` was measured against |
 | `stages` | array | every stage the run considered, in the order it reported them |
+
+`status` alone does not say what a run is evidence for. A green run scoped to
+three test files and a green full run are different claims, so **anything that
+ratchets a recorded number, moves a baseline, or gates a merge has to check
+`scope` and refuse to move on anything but `"all"`.** That is what the field is
+for.
+
+`scope` is the scope the run *achieved*. A `:changed` run that resolved to no
+test files ran the whole suite, so it reports `"all"` and puts the request on the
+Tests stage as `requested_scope` with a `fallback_reason` beside it. A caller
+checking `scope == "all"` never has to reason about fallbacks.
 
 ## Stage
 
@@ -78,6 +98,46 @@ command itself said.
 
 **Every stage the run considered appears**, skipped ones included, so absence is
 never something a caller has to interpret.
+
+## The Tests stage
+
+The Tests stage carries what it ran as well as what it found, because a test
+count says nothing about how much of the suite produced it:
+
+```json
+{
+  "name": "Tests",
+  "status": "ok",
+  "summary": "12 of 12 passed (scope changed, 3 files vs origin/main, no coverage)",
+  "scope": "changed",
+  "files": 3,
+  "test_files": [
+    "test/user_test.exs",
+    "test/user/email_test.exs",
+    "test/accounts_test.exs"
+  ],
+  "base_ref": "origin/main",
+  "coverage": "skipped",
+  "coverage_reason": "not measured on a scoped run",
+  "stats": {"test_count": 12, "passed_count": 12, "failed_count": 0},
+  "findings": [],
+  "duration_ms": 2800
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `scope` | string | always present, `"all"` for a full run |
+| `files` | integer | how many test files ran; absent on a full run |
+| `test_files` | array | which ones; absent on a full run |
+| `base_ref` | string | absent unless a diff was taken |
+| `coverage` | `"skipped"` | present only on a scoped run, where coverage is **absent rather than lower** |
+| `coverage_reason` | string | why it was not measured |
+| `requested_scope` | string | present only when the run fell back to the full suite |
+| `fallback_reason` | string | why it fell back, e.g. `no test files map to the changed files` |
+
+A scoped run never reports a coverage percentage in `stats`. See
+[Test scope](configuration.md#test-scope).
 
 ## Custom stages
 

--- a/docs/stages.md
+++ b/docs/stages.md
@@ -323,9 +323,31 @@ Runs `mix test`, or `mix coveralls` when coverage is being measured.
 Extra arguments reach the test command via `--` or `test: [args: [...]]`. See
 [configuration.md](configuration.md).
 
+### Running only part of the suite
+
+`--test-scope changed` runs only the test files covering the code that changed,
+which on a large suite is the difference between a check you can run between
+edits and one you cannot:
+
+```
+✓ Tests: 12 of 12 passed (scope changed, 3 files vs origin/main, no coverage) (2.8s)
+```
+
+A scope that resolves to no test files runs the whole suite rather than reporting
+a green run of nothing, and says so:
+
+```
+✓ Tests: 4,180 of 4,180 passed (scope changed fell back to the full suite: no test files map to the changed files) (56.8s)
+```
+
+Coverage on a scoped run is absent, not lower. See
+[Test scope](configuration.md#test-scope) for the mapping rules and
+[Reports](reports.md#the-tests-stage) for what the report carries.
+
 ## Coverage
 
-Coverage is part of the Tests stage, and `--quick` turns it off.
+Coverage is part of the Tests stage. `--quick` turns it off, and a scoped run has
+none to turn off.
 
 **The threshold is not configured in ExQuality.** It is read from whichever
 coverage tool the project already uses, so there is one source of truth:

--- a/fixtures/with_config/.quality.exs
+++ b/fixtures/with_config/.quality.exs
@@ -7,6 +7,13 @@
   dialyzer: [
     enabled: false
   ],
+  profiles: [
+    # A named fast path. Everything else, including the project's own stages, is
+    # reported as skipped naming the profile.
+    loop: [stages: [:format, :compile, :credo]],
+    # A profile that only carries options narrows nothing.
+    gate: []
+  ],
   custom: [
     # A command stage printing the JSON finding contract.
     [

--- a/lib/ex_quality/config.ex
+++ b/lib/ex_quality/config.ex
@@ -6,7 +6,8 @@ defmodule ExQuality.Config do
   1. Defaults
   2. Auto-detected tool availability
   3. Project config file (.quality.exs, read from the project root)
-  4. CLI arguments
+  4. The selected profile, if `--profile` named one
+  5. CLI arguments
 
   ## Example .quality.exs
 
@@ -26,6 +27,12 @@ defmodule ExQuality.Config do
         # Doctor options
         doctor: [
           summary_only: true
+        ],
+
+        # Named bundles, selected with `mix quality --profile loop`
+        profiles: [
+          loop: [stages: [:format, :compile, :credo], test: [scope: :changed]],
+          gate: []
         ]
       ]
 
@@ -34,6 +41,7 @@ defmodule ExQuality.Config do
   ### Global Options
 
   - `quick` - Quick mode: skip dialyzer and coverage enforcement (default: false)
+  - `profiles` - Named option bundles, see "Profiles" below (default: `[]`)
 
   ### Stage Options
 
@@ -61,11 +69,42 @@ defmodule ExQuality.Config do
     counting them (default: false)
   - `test.coverage` - :auto (measure when the project's config asks for it) |
     true (always measure) | false (never measure) (default: :auto)
+  - `test.scope` - :all (the whole suite) | :changed (only the test files
+    covering changed code) | a glob string (default: :all)
+  - `test.base_ref` - What `scope: :changed` is measured against (default: the
+    repository's default branch)
+
+  ## Profiles
+
+  A profile is a named bundle of the options above, so the fast path a project
+  wants its agents to use has a name its docs can point at:
+
+      profiles: [
+        loop: [stages: [:format, :compile, :credo], test: [scope: :changed]],
+        gate: []
+      ]
+
+  `mix quality --profile loop` merges the profile over the config file and under
+  the CLI, so a switch still wins over the profile that a run selected.
+
+  `stages:` is the allow-list of stage keys for the profile. Every other stage,
+  built-in or custom, is reported as skipped naming the profile. A profile with
+  no `stages:` key narrows nothing and only carries options, which is what an
+  empty `gate: []` is for.
+
+  An invocation with no `--profile` behaves exactly as it does without any
+  profiles configured. An unknown profile name fails the run: falling back to
+  "run everything" would turn a typo into a slow green, and falling back to the
+  profile's intent would turn one into a fast green over nothing.
   """
 
   @defaults [
     # Global options
     quick: false,
+
+    # Named option bundles, selected with --profile. Empty by default: this is
+    # a 0.x library with real users, and the unprofiled path does not move.
+    profiles: [],
 
     # Stage-specific options
     compile: [
@@ -115,7 +154,12 @@ defmodule ExQuality.Config do
       # threshold comes from the tool's own config, not from here.
       # In quick mode: runs mix test only (no coverage enforcement)
       coverage: :auto,
-      args: []
+      args: [],
+      # How much of the suite to run. See `ExQuality.Scope`. :all is what an
+      # unscoped run has always done, and narrowing is opt-in because a scope
+      # that resolves to nothing is the one way this could report a false green.
+      scope: :all,
+      base_ref: nil
     ]
   ]
 
@@ -126,7 +170,8 @@ defmodule ExQuality.Config do
   1. Defaults
   2. Auto-detected tool availability
   3. .quality.exs file
-  4. CLI arguments
+  4. The profile named by `--profile`, if any
+  5. CLI arguments
 
   ## Examples
 
@@ -147,6 +192,7 @@ defmodule ExQuality.Config do
       defaults
       |> deep_merge(detected)
       |> deep_merge(file_config)
+      |> apply_profile(Keyword.get(cli_opts, :profile))
       |> deep_merge(cli_config)
 
     # A custom stage that is malformed does not register, and a stage that does
@@ -155,6 +201,125 @@ defmodule ExQuality.Config do
     ExQuality.Custom.validate!(config)
 
     config
+  end
+
+  @doc """
+  Returns the name of the profile a loaded config was resolved with, or `nil`.
+
+      iex> ExQuality.Config.profile(ExQuality.Config.load())
+      nil
+  """
+  @spec profile(keyword()) :: atom() | nil
+  def profile(config), do: Keyword.get(config, :profile)
+
+  @doc """
+  Merges the named profile into a config, or returns it unchanged for `nil`.
+
+  Called by `load/1` between the config file and the CLI. `name` is a string
+  because it comes from a switch, and the profile keys it is matched against are
+  atoms because they come from a config file.
+
+      iex> ExQuality.Config.apply_profile([credo: [strict: true]], nil)
+      [credo: [strict: true]]
+
+      iex> config = [profiles: [loop: [test: [scope: :changed]]]]
+      iex> config |> ExQuality.Config.apply_profile("loop") |> Keyword.take([:profile, :test])
+      [profile: :loop, test: [scope: :changed]]
+  """
+  @spec apply_profile(keyword(), String.t() | nil) :: keyword()
+  def apply_profile(config, nil), do: config
+
+  def apply_profile(config, name) do
+    {key, profile} = fetch_profile!(config, name)
+
+    config
+    |> deep_merge(Keyword.delete(profile, :stages))
+    |> deep_merge(profile_skips(config, profile, key))
+    |> Keyword.put(:profile, key)
+  end
+
+  # Every stage key a profile's `stages:` list can allow. A custom stage's key is
+  # added from the config, so a profile narrows a project's own checks the same
+  # way it narrows the built-in ones.
+  @profileable_keys [
+    :format,
+    :compile,
+    :test,
+    :credo,
+    :dialyzer,
+    :doctor,
+    :gettext,
+    :sobelow,
+    :dependencies
+  ]
+
+  # An unknown name is an error, and the error lists what is known: the usual
+  # cause is a profile that was never added to this project's .quality.exs.
+  defp fetch_profile!(config, name) do
+    profiles = profiles(config)
+
+    case Enum.find(profiles, fn {key, _opts} -> to_string(key) == name end) do
+      {key, opts} when is_list(opts) ->
+        {key, opts}
+
+      {key, opts} ->
+        Mix.raise("Profile #{inspect(key)} must be a keyword list, got: #{inspect(opts)}")
+
+      nil ->
+        Mix.raise(
+          "Unknown --profile #{inspect(name)}. " <>
+            known_profiles(profiles) <> " Profiles are declared under profiles: in .quality.exs."
+        )
+    end
+  end
+
+  defp known_profiles([]), do: "No profiles are configured."
+
+  defp known_profiles(profiles) do
+    "Known profiles: " <>
+      Enum.map_join(profiles, ", ", fn {key, _opts} -> inspect(key) end) <> "."
+  end
+
+  defp profiles(config) do
+    case Keyword.get(config, :profiles, []) do
+      profiles when is_list(profiles) ->
+        if Keyword.keyword?(profiles) do
+          profiles
+        else
+          Mix.raise("profiles: in .quality.exs must be a keyword list, got: #{inspect(profiles)}")
+        end
+
+      other ->
+        Mix.raise("profiles: in .quality.exs must be a keyword list, got: #{inspect(other)}")
+    end
+  end
+
+  # A stage left out of a profile's `stages:` is disabled the way a `--skip`
+  # disables one, so it is announced as skipped naming the profile rather than
+  # quietly missing from the run.
+  defp profile_skips(config, profile, name) do
+    case Keyword.fetch(profile, :stages) do
+      :error ->
+        []
+
+      {:ok, allowed} when is_list(allowed) ->
+        for key <- @profileable_keys ++ custom_keys(config), key not in allowed do
+          {key, [enabled: false, disabled_by: {:cli, "not in profile #{inspect(name)}"}]}
+        end
+
+      {:ok, other} ->
+        Mix.raise(
+          "stages: in profile #{inspect(name)} must be a list of stage keys, got: #{inspect(other)}"
+        )
+    end
+  end
+
+  defp custom_keys(config) do
+    config
+    |> ExQuality.Custom.stages()
+    |> Enum.flat_map(fn entry ->
+      if Keyword.keyword?(entry), do: List.wrap(Keyword.get(entry, :key)), else: []
+    end)
   end
 
   @doc """
@@ -347,7 +512,9 @@ defmodule ExQuality.Config do
     # --quick mode: skip dialyzer, skip coverage enforcement
     |> put_flag(opts, :quick)
     |> put_flag(opts, :verbose)
+    |> put_flag(opts, :until_first_failure)
     |> put_test_args(opts)
+    |> put_test_scope(opts)
     |> annotate_disabled(:cli)
   end
 
@@ -370,7 +537,28 @@ defmodule ExQuality.Config do
   end
 
   defp put_test_args(config, opts) do
-    if opts[:test_args], do: Keyword.put(config, :test, args: opts[:test_args]), else: config
+    if opts[:test_args], do: put_test_option(config, :args, opts[:test_args]), else: config
+  end
+
+  # `--test-scope` is parsed here rather than at the switch, so a bad value fails
+  # the run with the same message a bad `.quality.exs` value gets.
+  defp put_test_scope(config, opts) do
+    case Keyword.fetch(opts, :test_scope) do
+      :error ->
+        config
+
+      {:ok, value} ->
+        case ExQuality.Scope.parse(value) do
+          {:ok, scope} -> put_test_option(config, :scope, scope)
+          {:error, message} -> Mix.raise("Invalid --test-scope: #{message}")
+        end
+    end
+  end
+
+  # `test:` can be set by more than one switch, so each one merges into whatever
+  # the last put there rather than replacing it.
+  defp put_test_option(config, key, value) do
+    Keyword.update(config, :test, [{key, value}], &Keyword.put(&1, key, value))
   end
 
   defp deep_merge(left, right) do

--- a/lib/ex_quality/report.ex
+++ b/lib/ex_quality/report.ex
@@ -17,6 +17,9 @@ defmodule ExQuality.Report do
         "version": "0.6.0",
         "status": "error",
         "duration_ms": 48213,
+        "profile": "loop",
+        "scope": "changed",
+        "base_ref": "origin/main",
         "stages": [
           {
             "name": "Credo",
@@ -49,15 +52,28 @@ defmodule ExQuality.Report do
   under `output` instead, mirroring the human renderer. Findings are the parsed
   form; `output` is the fallback, and one of the two is always present for a
   failure.
+
+  ## How much the run covered
+
+  `profile`, `scope` and `base_ref` are always present at the root, `null` when
+  they do not apply. They are what makes `"status": "ok"` interpretable: a green
+  run scoped to three test files is not the same claim as a green full run, and a
+  caller that lowers a recorded coverage figure or moves a baseline on a green
+  run has to be able to refuse the narrow one. The test stage repeats them, plus
+  the files it ran, in its own object. See `ExQuality.Scope`.
   """
 
   alias ExQuality.Finding
+  alias ExQuality.Scope
   alias ExQuality.Stage
 
   @type t :: %{
           version: String.t(),
           status: String.t(),
           duration_ms: non_neg_integer(),
+          profile: String.t() | nil,
+          scope: String.t() | nil,
+          base_ref: String.t() | nil,
           stages: [map()]
         }
 
@@ -67,20 +83,51 @@ defmodule ExQuality.Report do
   `duration_ms` is the wall clock time of the whole run, which is not the sum
   of the stage durations because the analysis stages run in parallel.
 
+  `config` is the run's loaded config, used for the root `profile` and for the
+  scope when the test stage did not run to report one of its own.
+
       iex> alias ExQuality.{Report, Stage}
       iex> report = Report.build([Stage.skipped("Dialyzer", "--quick")], 12)
       iex> {report.status, report.duration_ms, length(report.stages)}
       {"ok", 12, 1}
+
+      iex> alias ExQuality.{Report, Stage}
+      iex> report = Report.build([Stage.skipped("Tests", "--skip test")], 12, profile: :loop)
+      iex> {report.profile, report.scope}
+      {"loop", "all"}
   """
-  @spec build([Stage.result()], non_neg_integer()) :: t()
-  def build(results, duration_ms) do
+  @spec build([Stage.result()], non_neg_integer(), keyword()) :: t()
+  def build(results, duration_ms, config \\ []) do
+    coverage = coverage(results, config)
+
     %{
       version: version(),
       status: overall_status(results),
       duration_ms: duration_ms,
+      profile: config |> Keyword.get(:profile) |> maybe_string(),
+      scope: coverage.scope,
+      base_ref: coverage.base_ref,
       stages: Enum.map(results, &stage/1)
     }
   end
+
+  # The test stage is the only stage that narrows scope, so its own account of
+  # what it ran is the root's. A run where it did not run at all reports what was
+  # asked for, which is the closest thing to true available.
+  defp coverage(results, config) do
+    meta =
+      results
+      |> Enum.find(%{}, &(&1.name == "Tests"))
+      |> Map.get(:meta, %{})
+
+    %{
+      scope: Map.get(meta, :scope) || Scope.describe(Scope.from_config(config)),
+      base_ref: Map.get(meta, :base_ref)
+    }
+  end
+
+  defp maybe_string(nil), do: nil
+  defp maybe_string(value), do: to_string(value)
 
   @doc """
   Encodes a report as pretty-printed JSON, newline terminated.
@@ -115,6 +162,7 @@ defmodule ExQuality.Report do
       stats: stats(result.stats),
       findings: Enum.map(findings, &finding/1)
     }
+    |> Map.merge(Map.get(result, :meta, %{}))
     |> put_output(result, findings)
   end
 

--- a/lib/ex_quality/scope.ex
+++ b/lib/ex_quality/scope.ex
@@ -1,0 +1,318 @@
+defmodule ExQuality.Scope do
+  @moduledoc """
+  Resolves *how much code* a stage runs over, as opposed to *which stages* run.
+
+  Every skip switch this library has narrows stages. An agent iterating on one
+  file does not want fewer checks, it wants the same checks over less code: on a
+  3,700-test umbrella the suite is 68% of a run's wall clock, and a one-file
+  change needs a handful of test files rather than all of them.
+
+  A scope is one of:
+
+  - `:all` - everything, which is what an unscoped run has always done
+  - `:changed` - the test files that map to the files changed against a base ref
+  - a glob string - the test files matching it
+
+  ## The one failure mode that matters
+
+  A scoped run that resolves to no files must never report green, because it
+  fails in the safe-looking direction: `mix quality` exits 0, the report says
+  `"status": "ok"`, and nothing ran. So an empty resolution is not an empty run,
+  it falls back to the full suite and says why in `fallback_reason`.
+
+  For the same reason `resolve/2` reports the scope it *achieved*, not the one it
+  was asked for. A run that fell back reports `scope: :all` with the request
+  kept in `requested_scope`, so a caller that refuses to move a baseline on a
+  scoped run does not have to reason about fallbacks.
+
+  ## Uncommitted work counts
+
+  An agent mid-task has everything uncommitted, so a diff that reads only
+  committed history reports no changes on exactly the runs this exists for.
+  `:changed` reads the working tree against the merge base with the base ref,
+  and folds in untracked files.
+
+  ## Example
+
+      ExQuality.Scope.resolve(:changed, base_ref: "origin/main")
+      #=> %{
+      #=>   scope: :changed,
+      #=>   requested_scope: :changed,
+      #=>   files: ["test/user_test.exs"],
+      #=>   base_ref: "origin/main",
+      #=>   fallback_reason: nil
+      #=> }
+  """
+
+  @typedoc "A requested scope."
+  @type t :: :all | :changed | {:glob, String.t()}
+
+  @typedoc """
+  What a scope resolved to.
+
+  `files` is `:all` for a full suite, which is not the same as `[]`: an empty
+  list would be a run of nothing.
+  """
+  @type resolved :: %{
+          scope: :all | :changed | {:glob, String.t()},
+          requested_scope: t(),
+          files: :all | [String.t()],
+          base_ref: String.t() | nil,
+          fallback_reason: String.t() | nil
+        }
+
+  # Ordered by how likely each is to be the trunk of a repository that has not
+  # told us. `origin/HEAD` is asked first because it is the repository's own
+  # answer rather than a guess.
+  @base_ref_candidates ["origin/main", "origin/master", "main", "master"]
+
+  @doc """
+  Parses a scope written by a human, in `.quality.exs` or on the command line.
+
+  Anything that is not `all` or `changed` is a glob, because a glob is the only
+  one of the three that has to carry a value.
+
+      iex> ExQuality.Scope.parse("changed")
+      {:ok, :changed}
+
+      iex> ExQuality.Scope.parse(:all)
+      {:ok, :all}
+
+      iex> ExQuality.Scope.parse("test/unit/**/*_test.exs")
+      {:ok, {:glob, "test/unit/**/*_test.exs"}}
+
+      iex> ExQuality.Scope.parse(42)
+      {:error, "test scope must be :all, :changed or a glob string, got: 42"}
+  """
+  @spec parse(term()) :: {:ok, t()} | {:error, String.t()}
+  def parse(:all), do: {:ok, :all}
+  def parse("all"), do: {:ok, :all}
+  def parse(:changed), do: {:ok, :changed}
+  def parse("changed"), do: {:ok, :changed}
+  # Idempotent, so an already-parsed scope can be put back into the config and
+  # read out of it again.
+  def parse({:glob, glob} = scope) when is_binary(glob) and glob != "", do: {:ok, scope}
+  def parse(glob) when is_binary(glob) and glob != "", do: {:ok, {:glob, glob}}
+
+  def parse(other) do
+    {:error, "test scope must be :all, :changed or a glob string, got: #{inspect(other)}"}
+  end
+
+  @doc """
+  Returns the scope a loaded config asks the test stage for.
+
+  Raises when the config names something that is not a scope, rather than
+  falling back to `:all`: a typo that silently ran everything would be slow, and
+  one that silently ran nothing would be a green run of no tests.
+
+      iex> ExQuality.Scope.from_config([])
+      :all
+
+      iex> ExQuality.Scope.from_config(test: [scope: :changed])
+      :changed
+  """
+  @spec from_config(keyword()) :: t()
+  def from_config(config) do
+    value = config |> Keyword.get(:test, []) |> Keyword.get(:scope, :all)
+
+    case parse(value) do
+      {:ok, scope} -> scope
+      {:error, message} -> Mix.raise(message)
+    end
+  end
+
+  @doc """
+  Renders a scope for the report and for human output.
+
+      iex> ExQuality.Scope.describe(:all)
+      "all"
+
+      iex> ExQuality.Scope.describe({:glob, "test/unit/**"})
+      "test/unit/**"
+  """
+  @spec describe(t()) :: String.t()
+  def describe(:all), do: "all"
+  def describe(:changed), do: "changed"
+  def describe({:glob, glob}), do: glob
+
+  @doc """
+  Resolves a scope to the test files to run.
+
+  ## Options
+
+  - `:base_ref` - what `:changed` is measured against (default: the repository's
+    default branch, see `default_base_ref/0`)
+  """
+  @spec resolve(t(), keyword()) :: resolved()
+  def resolve(scope, opts \\ [])
+
+  def resolve(:all, _opts), do: full(:all, nil, nil)
+
+  def resolve(:changed, opts) do
+    base_ref = Keyword.get(opts, :base_ref) || default_base_ref()
+
+    case changed_files(base_ref) do
+      {:ok, changed} ->
+        scoped(:changed, test_files(changed), base_ref, "no test files map to the changed files")
+
+      {:error, reason} ->
+        full(:changed, base_ref, reason)
+    end
+  end
+
+  def resolve({:glob, glob} = scope, _opts) do
+    matches = glob |> Path.wildcard() |> Enum.filter(&test_file?/1) |> Enum.sort()
+
+    scoped(scope, matches, nil, "the glob matched no test files")
+  end
+
+  # An empty resolution runs everything. See the moduledoc: a scoped green over
+  # nothing is the one outcome that would make this worse than not having it.
+  defp scoped(scope, [], base_ref, reason), do: full(scope, base_ref, reason)
+
+  defp scoped(scope, files, base_ref, _reason) do
+    %{
+      scope: scope,
+      requested_scope: scope,
+      files: files,
+      base_ref: base_ref,
+      fallback_reason: nil
+    }
+  end
+
+  defp full(requested, base_ref, reason) do
+    %{
+      scope: :all,
+      requested_scope: requested,
+      files: :all,
+      base_ref: base_ref,
+      fallback_reason: reason
+    }
+  end
+
+  @doc """
+  Returns the ref `:changed` is measured against when nothing names one.
+
+  The repository's own `origin/HEAD` is preferred, because a repository whose
+  trunk is neither `main` nor `master` has still recorded which one it is.
+  Returns `nil` outside a git repository, which `resolve/2` turns into a full
+  suite rather than a failure.
+  """
+  @spec default_base_ref() :: String.t() | nil
+  def default_base_ref do
+    case git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]) do
+      {:ok, ref} -> ref
+      {:error, _reason} -> Enum.find(@base_ref_candidates, &ref_exists?/1)
+    end
+  end
+
+  defp ref_exists?(ref) do
+    match?({:ok, _sha}, git(["rev-parse", "--verify", "--quiet", ref <> "^{commit}"]))
+  end
+
+  # Everything changed since the branch point, plus everything not yet
+  # committed. The merge base rather than the ref itself, so commits landed on
+  # the trunk since the branch started do not read as this branch's work.
+  defp changed_files(nil), do: {:error, "no base ref could be determined"}
+
+  defp changed_files(base_ref) do
+    with {:ok, root} <- git(["rev-parse", "--show-toplevel"]),
+         {:ok, base} <- merge_base(base_ref) do
+      {:ok, tracked_changes(base) ++ untracked_files()} |> relative_to(root)
+    else
+      {:error, _reason} -> {:error, "#{inspect(base_ref)} is not a ref in a git repository here"}
+    end
+  end
+
+  defp merge_base(base_ref) do
+    case git(["merge-base", "HEAD", base_ref]) do
+      {:ok, sha} -> {:ok, sha}
+      # An unrelated history, or a shallow clone with no common commit. The ref
+      # itself is still a usable comparison point.
+      {:error, _reason} -> if ref_exists?(base_ref), do: {:ok, base_ref}, else: {:error, :no_base}
+    end
+  end
+
+  # `-d` drops deletions: a deleted source file has no test to run, and a
+  # deleted test file cannot be pointed at.
+  defp tracked_changes(base) do
+    case git(["diff", "--name-only", "--diff-filter=d", base]) do
+      {:ok, output} -> lines(output)
+      {:error, _reason} -> []
+    end
+  end
+
+  defp untracked_files do
+    case git(["ls-files", "--others", "--exclude-standard"]) do
+      {:ok, output} -> lines(output)
+      {:error, _reason} -> []
+    end
+  end
+
+  # git reports paths from the repository root, and a run may be started from a
+  # directory below it, so they are put back into the caller's terms.
+  defp relative_to({:ok, paths}, root) do
+    {:ok, Enum.map(paths, &(root |> Path.join(&1) |> Path.relative_to_cwd()))}
+  end
+
+  defp lines(output) do
+    output |> String.split("\n", trim: true) |> Enum.map(&String.trim/1)
+  end
+
+  @doc """
+  Maps changed files to the test files that cover them.
+
+  A changed test file is itself. A changed source file is the test file beside
+  it, `lib/foo/bar.ex` to `test/foo/bar_test.exs`, which works unchanged in an
+  umbrella because `apps/web/lib/foo.ex` maps under `apps/web/test/`.
+
+  Only files that exist are returned. Everything else - a changed `mix.exs`, a
+  source file with no test - contributes nothing, and contributing nothing is
+  what makes `resolve/2` fall back to the full suite.
+
+      iex> ExQuality.Scope.test_files(["mix.exs"])
+      []
+  """
+  @spec test_files([String.t()]) :: [String.t()]
+  def test_files(changed) do
+    changed
+    |> Enum.flat_map(fn path ->
+      cond do
+        test_file?(path) -> [path]
+        mapped = mapped_test_file(path) -> [mapped]
+        true -> []
+      end
+    end)
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp test_file?(path), do: String.ends_with?(path, "_test.exs")
+
+  defp mapped_test_file(path) do
+    segments = Path.split(path)
+
+    with true <- String.ends_with?(path, ".ex"),
+         index when is_integer(index) <- Enum.find_index(segments, &(&1 == "lib")) do
+      segments
+      |> List.replace_at(index, "test")
+      |> Path.join()
+      |> String.replace_suffix(".ex", "_test.exs")
+    else
+      _no_mapping -> nil
+    end
+  end
+
+  # git is asked about the repository, never told to change it, so a failure here
+  # is always "this question has no answer" rather than something to report.
+  defp git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, "git #{hd(args)} exited #{code}: #{String.trim(output)}"}
+    end
+  rescue
+    # No git on PATH at all.
+    ErlangError -> {:error, "git is not available"}
+  end
+end

--- a/lib/ex_quality/stage.ex
+++ b/lib/ex_quality/stage.ex
@@ -16,6 +16,15 @@ defmodule ExQuality.Stage do
   1. If `findings` is non-empty, render the findings.
   2. Otherwise, print `output` verbatim. Unparseable output is never hidden.
 
+  ## Metadata
+
+  A stage may also return `meta`, a map of extra report fields describing *what
+  the stage did* rather than what it found. The test stage uses it to say how
+  much of the suite it ran, because `"status": "ok"` over three test files and
+  `"status": "ok"` over the whole suite are different claims and a consumer has
+  to be able to tell them apart. Keys are merged into the stage's object in the
+  JSON report.
+
   ## Skipped stages
 
   A stage that was considered and not run returns a `:skipped` result carrying
@@ -74,7 +83,8 @@ defmodule ExQuality.Stage do
           required(:stats) => stats(),
           required(:summary) => String.t(),
           required(:duration_ms) => non_neg_integer(),
-          optional(:findings) => [Finding.t()]
+          optional(:findings) => [Finding.t()],
+          optional(:meta) => %{atom() => term()}
         }
 
   @doc """

--- a/lib/ex_quality/stages/test.ex
+++ b/lib/ex_quality/stages/test.ex
@@ -64,10 +64,30 @@ defmodule ExQuality.Stages.Test do
   are the ones a reader acts on. Modules are reported only when the run actually
   failed on coverage, because the threshold applies to the total: a passing run
   can hold a low module and there is nothing to do about it.
+
+  ## Scoped runs
+
+  `test: [scope: :changed]`, or `--test-scope changed`, runs only the test files
+  covering the code that changed. This is the whole reason an agent can afford to
+  run checks between edits: the suite is most of a run's wall clock, and a
+  one-file change needs a handful of files rather than all of them. See
+  `ExQuality.Scope`, which owns resolving the scope and the rule that an empty
+  resolution runs the full suite rather than reporting a green run of nothing.
+
+  Coverage in a scoped run is not lower, it is **absent**. It is reported as
+  `skipped` with a reason and never as a number, because a percentage measured
+  over a subset of the suite is not a smaller truth, it is a different and
+  misleading one, and anything downstream that ratchets a recorded figure would
+  lower it against a run that never measured.
+
+  The result carries what the run actually covered under `meta`, so a
+  `"status": "ok"` in the report can be interpreted rather than assumed to be a
+  full green.
   """
 
   alias ExQuality.Aliases
   alias ExQuality.Finding
+  alias ExQuality.Scope
   alias ExQuality.Umbrella
 
   # Elixir's documented aggregation workflow names the export "default", and
@@ -83,16 +103,26 @@ defmodule ExQuality.Stages.Test do
   - `test.args` - Extra arguments for the test command (default: `[]`)
   - `test.coverage` - `:auto` (use the project's config) | `true` (always
     measure) | `false` (never measure) (default: `:auto`)
+  - `test.scope` - `:all` | `:changed` | a glob string (default: `:all`)
+  - `test.base_ref` - What `:changed` is measured against (default: the
+    repository's default branch)
   """
   @spec run(keyword()) :: ExQuality.Stage.result()
   def run(config) do
-    mode = coverage_mode(config)
+    scope = resolve_scope(config)
+    mode = coverage_mode(config, scope)
 
     if aggregating?(mode) and Aliases.shadowing?("test.coverage") do
       Aliases.shadowed("Tests", "test.coverage")
     else
-      test(config, mode)
+      test(config, mode, scope)
     end
+  end
+
+  defp resolve_scope(config) do
+    base_ref = config |> Keyword.get(:test, []) |> Keyword.get(:base_ref)
+
+    config |> Scope.from_config() |> Scope.resolve(base_ref: base_ref)
   end
 
   # A `test:` alias is near-universal and running it is correct: it does the
@@ -101,12 +131,12 @@ defmodule ExQuality.Stages.Test do
   # only trace is a doubled test count and a doubled wall clock.
   defp aggregating?(mode), do: mode == :native and Umbrella.umbrella?()
 
-  defp test(config, mode) do
+  defp test(config, mode, scope) do
     start_time = System.monotonic_time(:millisecond)
 
     test_args = config |> Keyword.get(:test, []) |> Keyword.get(:args, [])
 
-    {output, exit_code} = run_tests(mode, test_args)
+    {output, exit_code} = run_tests(mode, test_args, scope.files)
 
     duration_ms = System.monotonic_time(:millisecond) - start_time
     %{stats: stats, findings: findings} = analyze(output, mode)
@@ -117,18 +147,21 @@ defmodule ExQuality.Stages.Test do
       output: output,
       findings: findings,
       stats: stats,
-      summary: summary(stats, mode, exit_code),
-      duration_ms: duration_ms
+      summary: summary(stats, mode, exit_code) <> scope_summary(scope),
+      duration_ms: duration_ms,
+      meta: meta(scope, mode)
     }
   end
 
   # `:coveralls` and `:native` differ only in which tool measures; `:plain`
-  # means nothing measures.
-  defp coverage_mode(config) do
+  # means nothing measures. A scoped run is always `:plain`: see the moduledoc
+  # on why a subset percentage is worse than no percentage.
+  defp coverage_mode(config, scope) do
     test_config = Keyword.get(config, :test, [])
     requested = Keyword.get(test_config, :coverage, :auto)
 
     cond do
+      scope.files != :all -> :plain
       Keyword.get(config, :quick, false) -> :plain
       requested == false -> :plain
       ExQuality.Tools.available?(:coverage) -> :coveralls
@@ -139,9 +172,9 @@ defmodule ExQuality.Stages.Test do
     end
   end
 
-  defp run_tests(:coveralls, args), do: mix(["coveralls" | args])
+  defp run_tests(:coveralls, args, :all), do: mix(["coveralls" | args])
 
-  defp run_tests(:native, args) do
+  defp run_tests(:native, args, :all) do
     if Umbrella.umbrella?() do
       run_umbrella_coverage(args)
     else
@@ -149,7 +182,15 @@ defmodule ExQuality.Stages.Test do
     end
   end
 
-  defp run_tests(_plain, args), do: mix(["test" | args])
+  # Paths last, so an argument that takes a value cannot swallow one. In an
+  # umbrella the paths are relative to the root and `mix test` routes each to the
+  # app that owns it, skipping the apps no path names.
+  defp run_tests(_plain, args, files) do
+    mix(["test"] ++ args ++ paths(files))
+  end
+
+  defp paths(:all), do: []
+  defp paths(files), do: files
 
   # Exporting suppresses the summary and the threshold check, so the aggregate
   # run is where coverage is decided. A failing suite skips it: mix stops at the
@@ -525,6 +566,63 @@ defmodule ExQuality.Stages.Test do
       _module -> Mix.Project.build_path() |> Path.dirname() |> Path.join("test")
     end
   end
+
+  # What the run covered, for the report. Always carries `scope`, including on a
+  # full run: a consumer that has to branch on whether the key is there cannot
+  # tell "full suite" from "an older ExQuality that never said".
+  defp meta(scope, mode) do
+    %{scope: Scope.describe(scope.scope)}
+    |> put_files(scope)
+    |> put_base_ref(scope)
+    |> put_coverage(scope, mode)
+  end
+
+  defp put_base_ref(meta, %{base_ref: nil}), do: meta
+  defp put_base_ref(meta, %{base_ref: ref}), do: Map.put(meta, :base_ref, ref)
+
+  # The count and the list: a count says how narrow the run was, and the list is
+  # what makes it checkable. Both are bounded by the size of the change.
+  defp put_files(meta, %{fallback_reason: nil, files: files}) when is_list(files) do
+    Map.merge(meta, %{files: length(files), test_files: files})
+  end
+
+  defp put_files(meta, %{fallback_reason: nil}), do: meta
+
+  # A run that fell back reports the scope it achieved, with the request and the
+  # reason beside it. Nothing downstream should treat it as narrowed, because it
+  # was not.
+  defp put_files(meta, scope) do
+    Map.merge(meta, %{
+      requested_scope: Scope.describe(scope.requested_scope),
+      fallback_reason: scope.fallback_reason
+    })
+  end
+
+  defp put_coverage(meta, %{files: files}, :plain) when is_list(files) do
+    Map.merge(meta, %{coverage: "skipped", coverage_reason: "not measured on a scoped run"})
+  end
+
+  defp put_coverage(meta, _scope, _mode), do: meta
+
+  # Base refs are only interesting when a diff was taken against one.
+  defp base_ref_summary(%{base_ref: nil}), do: ""
+  defp base_ref_summary(%{base_ref: ref}), do: " vs #{ref}"
+
+  defp scope_summary(%{scope: :all, requested_scope: :all}), do: ""
+
+  defp scope_summary(%{fallback_reason: reason} = scope) when is_binary(reason) do
+    " (scope #{Scope.describe(scope.requested_scope)} fell back to the full suite: #{reason})"
+  end
+
+  defp scope_summary(%{files: files} = scope) when is_list(files) do
+    " (scope #{Scope.describe(scope.scope)}, #{length(files)} #{pluralize(files, "file")}" <>
+      base_ref_summary(scope) <> ", no coverage)"
+  end
+
+  defp scope_summary(_scope), do: ""
+
+  defp pluralize([_one], word), do: word
+  defp pluralize(_many, word), do: word <> "s"
 
   defp summary(stats, mode, 0), do: format_success_summary(stats, mode)
   defp summary(stats, mode, _error), do: format_failure_summary(stats, mode)

--- a/lib/mix/tasks/quality.ex
+++ b/lib/mix/tasks/quality.ex
@@ -27,9 +27,13 @@ defmodule Mix.Tasks.Quality do
   - `--skip-sobelow` - Skip Sobelow security analysis
   - `--skip-dependencies` - Skip dependency checks (unused deps and security audit)
   - `--skip KEY` - Skip any stage by key, built-in or custom; repeatable
+  - `--profile NAME` - Run a named bundle of options from `.quality.exs`
+  - `--test-scope all|changed|GLOB` - How much of the suite to run
+  - `--until-first-failure` - Stop at the first failing stage, cheapest first
   - `--verbose` - Show full output even on success
   - `--format json` - Write a JSON report to stdout, human output to stderr
   - `--report PATH` - Write a JSON report to PATH, human output to stdout
+    (`--report -` writes it to stdout, as `--format json` does)
 
   ## Passing Test Options
 
@@ -70,6 +74,35 @@ defmodule Mix.Tasks.Quality do
     coverage threshold is not enforced)
 
   This lets you iterate quickly while still catching obvious issues.
+
+  ## An inner loop, as opposed to a gate
+
+  A full run is a good thing to require before a push and a bad thing to run
+  between edits, and every switch above narrows *which checks run* when the
+  expensive question is *how much code they run over*. On a large suite the tests
+  are most of the wall clock, and `--quick` does not touch them: it removes
+  dialyzer and the coverage threshold and still runs every test.
+
+      mix quality --test-scope changed        # only the tests covering your edits
+      mix quality --profile loop             # a named bundle, see below
+      mix quality --until-first-failure      # stop at the first thing to fix
+
+  `--test-scope changed` maps the files you have changed, committed or not, to
+  the test files covering them. A scope that resolves to no test files runs the
+  whole suite instead, because a green run of nothing is the one result that
+  would be worse than a slow one. Coverage is reported as skipped on a scoped
+  run, never as a number over a subset. See `ExQuality.Scope`.
+
+  A profile gives that fast path a name, so a project's docs and its agent
+  instructions can point at one word instead of a switch list:
+
+      profiles: [
+        loop: [stages: [:format, :compile, :credo], test: [scope: :changed]],
+        gate: []
+      ]
+
+  A run with no `--profile` behaves exactly as it did before profiles existed.
+  See `ExQuality.Config` for how a profile merges, and what an unknown name does.
 
   ## Configuration
 
@@ -165,9 +198,32 @@ defmodule Mix.Tasks.Quality do
     skip_sobelow: :boolean,
     skip_dependencies: :boolean,
     skip: :keep,
+    profile: :string,
+    test_scope: :string,
+    until_first_failure: :boolean,
     verbose: :boolean,
     format: :string,
     report: :string
+  ]
+
+  # Cheapest first, for --until-first-failure. An iterating caller does not need
+  # a full battery report, it needs the next thing to fix, and paying a minute of
+  # tests to be told about a formatting error is the opposite of that. The order
+  # is stated rather than derived because the analysis phase runs in parallel and
+  # so has never needed one. A custom stage's cost is unknown, so it is placed
+  # with the linters: they are what a project's own checks usually are, and being
+  # wrong there costs a few seconds rather than a suite.
+  @cost_order [
+    :format,
+    :compile,
+    :dependencies,
+    :sobelow,
+    :gettext,
+    :credo,
+    :doctor,
+    :custom,
+    :dialyzer,
+    :test
   ]
 
   @doc """
@@ -192,16 +248,23 @@ defmodule Mix.Tasks.Quality do
   end
 
   defp reporting(opts) do
-    format =
+    requested =
       case Keyword.get(opts, :format, "human") do
         "human" -> :human
         "json" -> :json
         other -> Mix.raise(~s(Unknown --format #{inspect(other)}. Expected "human" or "json".))
       end
 
+    path = Keyword.get(opts, :report)
+
+    # `--report -` is the shell's spelling of "to stdout", and a caller that
+    # wants the report there wants nothing else there: the human stream moves to
+    # stderr rather than being interleaved into JSON nobody can parse.
+    format = if path == "-", do: :json, else: requested
+
     %{
       format: format,
-      path: Keyword.get(opts, :report),
+      path: if(path == "-", do: nil, else: path),
       # Failure details are written verbatim rather than through the shell, so
       # they need to be told where the human stream went.
       device: if(format == :json, do: :stderr, else: :stdio)
@@ -213,12 +276,20 @@ defmodule Mix.Tasks.Quality do
 
     Mix.shell().info("Running quality checks...\n")
 
+    if Keyword.get(config, :until_first_failure, false) do
+      run_serially(config, started, reporting)
+    else
+      run_in_phases(config, started, reporting)
+    end
+  end
+
+  defp run_in_phases(config, started, reporting) do
     # Phase 1: Auto-fix (format)
-    format_result = Format.run(config)
+    format_result = run_or_skip(config, :format, "Format", &Format.run/1)
     display_phase_result(format_result)
 
     # Phase 2: Compile (blocking gate)
-    compile_result = Compile.run(config)
+    compile_result = run_or_skip(config, :compile, "Compile", &Compile.run/1)
     display_phase_result(compile_result)
 
     if compile_result.status == :error do
@@ -227,7 +298,13 @@ defmodule Mix.Tasks.Quality do
       not_run = analysis_stages_not_run(config, "compile failed")
       Enum.each(not_run, &display_phase_result/1)
 
-      finish([format_result, compile_result | not_run], started, reporting, "Compilation failed")
+      finish(
+        [format_result, compile_result | not_run],
+        started,
+        reporting,
+        config,
+        "Compilation failed"
+      )
     else
       # Phase 3: Analysis (parallel with streaming)
       Mix.shell().info("\nRunning analysis stages in parallel...\n")
@@ -235,13 +312,69 @@ defmodule Mix.Tasks.Quality do
       analysis_results = run_analysis_stages(config)
       all_results = [format_result, compile_result | analysis_results]
 
-      finish(all_results, started, reporting, nil)
+      finish(all_results, started, reporting, config, nil)
+    end
+  end
+
+  # `--until-first-failure`: one stage at a time, cheapest first, stopping at the
+  # first failure. Nothing runs in parallel here, which is the point: the run
+  # exists to name the next thing to fix, and a stage that would have taken a
+  # minute to also fail is a minute spent on something the caller is not going to
+  # read yet.
+  defp run_serially(config, started, reporting) do
+    {stages, skipped} = serial_stages(config)
+    Enum.each(skipped, &display_phase_result/1)
+
+    {ran, not_run} = run_until_failure(stages, config)
+
+    stopped = Enum.map(not_run, &Stage.skipped(&1.name, "--until-first-failure"))
+    Enum.each(stopped, &display_phase_result/1)
+
+    finish(skipped ++ ran ++ stopped, started, reporting, config, nil)
+  end
+
+  defp run_until_failure(stages, config) do
+    Enum.reduce_while(stages, {[], stages}, fn stage, {ran, remaining} ->
+      result = stage.run.(config)
+      display_phase_result(result)
+
+      ran = ran ++ [result]
+      remaining = tl(remaining)
+
+      if result.status == :error, do: {:halt, {ran, remaining}}, else: {:cont, {ran, remaining}}
+    end)
+  end
+
+  # Every stage of the run, runnable ones cheapest first. Unlike the phased path
+  # this includes format and compile, because with no parallel phase to sit ahead
+  # of they are just the two cheapest stages.
+  defp serial_stages(config) do
+    {stages, skipped} =
+      config
+      |> all_candidates()
+      |> Enum.split_with(&is_nil(&1.skip_reason))
+
+    {Enum.sort_by(stages, &cost_index(&1.key)),
+     Enum.map(skipped, &Stage.skipped(&1.name, &1.skip_reason))}
+  end
+
+  defp cost_index(key) do
+    Enum.find_index(@cost_order, &(&1 == key)) || Enum.find_index(@cost_order, &(&1 == :custom))
+  end
+
+  # A stage that a profile or a `--skip` turned off is reported as skipped rather
+  # than run. Format and compile have always run unconditionally, and they still
+  # do unless something says otherwise.
+  defp run_or_skip(config, key, name, run) do
+    case Config.skip_reason(config, key) do
+      nil -> run.(config)
+      reason -> Stage.skipped(name, reason)
     end
   end
 
   # One exit for every run: render the human verdict, emit the report, then
   # fail. The report is written before raising so a caller still gets it.
-  defp finish(results, started, reporting, message) do
+  defp finish(results, started, reporting, config, message) do
     failures = Enum.filter(results, &(&1.status == :error))
 
     if failures != [] do
@@ -251,17 +384,17 @@ defmodule Mix.Tasks.Quality do
       Mix.shell().info("\n✓ All quality checks passed!")
     end
 
-    emit_report(results, System.monotonic_time(:millisecond) - started, reporting)
+    emit_report(results, System.monotonic_time(:millisecond) - started, reporting, config)
 
     if failures != [] do
       Mix.raise(message || "#{length(failures)} quality check(s) failed")
     end
   end
 
-  defp emit_report(_results, _duration_ms, %{format: :human, path: nil}), do: :ok
+  defp emit_report(_results, _duration_ms, %{format: :human, path: nil}, _config), do: :ok
 
-  defp emit_report(results, duration_ms, reporting) do
-    json = results |> Report.build(duration_ms) |> Report.encode!()
+  defp emit_report(results, duration_ms, reporting, config) do
+    json = results |> Report.build(duration_ms, config) |> Report.encode!()
 
     if reporting.path, do: File.write!(reporting.path, json)
     if reporting.format == :json, do: IO.write(json)
@@ -300,18 +433,15 @@ defmodule Mix.Tasks.Quality do
     result
   end
 
-  # Every optional stage is either run or reported as skipped with its reason.
-  # Tests always run (but coverage enforcement is skipped in quick mode).
+  # Every stage is either run or reported as skipped with its reason. Tests run
+  # unless something turned them off explicitly - a `--skip test` or a profile
+  # that leaves them out - and quick mode narrows what they measure rather than
+  # whether they run.
   defp build_analysis_stages(config) do
-    {stages, skipped} =
-      Enum.reduce(candidate_stages(config), {[], []}, fn stage, {stages, skipped} ->
-        case stage.skip_reason do
-          nil -> {[stage | stages], skipped}
-          reason -> {stages, [Stage.skipped(stage.name, reason) | skipped]}
-        end
-      end)
+    candidates = candidate_stages(config) ++ [test_stage(config)]
+    {stages, skipped} = Enum.split_with(candidates, &is_nil(&1.skip_reason))
 
-    {Enum.reverse([test_stage(config) | stages]), Enum.reverse(skipped)}
+    {stages, Enum.map(skipped, &Stage.skipped(&1.name, &1.skip_reason))}
   end
 
   # Built-ins first, then the project's own stages, in declaration order. Both
@@ -343,8 +473,25 @@ defmodule Mix.Tasks.Quality do
     builtin ++ custom
   end
 
+  # Format and compile are phases rather than analysis stages in the default run,
+  # so they are only assembled as candidates for the serial path, which has no
+  # phases to be ahead of.
+  defp all_candidates(config) do
+    [
+      stage(:format, "Format", :writer, &Format.run/1, Config.skip_reason(config, :format)),
+      stage(:compile, "Compile", :writer, &Compile.run/1, Config.skip_reason(config, :compile)),
+      test_stage(config)
+    ] ++ candidate_stages(config)
+  end
+
   defp test_stage(config) do
-    stage(:test, "Tests", Stage.kind(Test, config), &Test.run/1, nil)
+    stage(
+      :test,
+      "Tests",
+      Stage.kind(Test, config),
+      &Test.run/1,
+      Config.skip_reason(config, :test)
+    )
   end
 
   defp stage(key, name, kind, run, skip_reason) do

--- a/test/ex_quality/config_test.exs
+++ b/test/ex_quality/config_test.exs
@@ -169,6 +169,121 @@ defmodule ExQuality.ConfigTest do
     end
   end
 
+  describe "apply_profile/2" do
+    @profiles [
+      profiles: [
+        loop: [stages: [:format, :compile, :credo], test: [scope: :changed]],
+        gate: []
+      ]
+    ]
+
+    test "returns the config untouched with no profile" do
+      assert Config.apply_profile(@profiles, nil) == @profiles
+    end
+
+    test "merges the profile's options" do
+      config = Config.apply_profile(@profiles, "loop")
+
+      assert config[:profile] == :loop
+      assert config[:test][:scope] == :changed
+    end
+
+    test "keeps options the profile does not mention" do
+      config = Config.apply_profile([credo: [strict: true]] ++ @profiles, "loop")
+
+      assert config[:credo][:strict] == true
+    end
+
+    test "skips every stage the profile leaves out, naming the profile" do
+      config = Config.apply_profile(@profiles, "loop")
+
+      assert Config.skip_reason(config, :dialyzer) == "not in profile :loop"
+      assert Config.skip_reason(config, :sobelow) == "not in profile :loop"
+      assert Config.skip_reason(config, :test) == "not in profile :loop"
+    end
+
+    test "runs the stages the profile lists" do
+      config = Config.apply_profile(@profiles, "loop")
+
+      assert Config.skip_reason(config, :format) == nil
+      assert Config.skip_reason(config, :compile) == nil
+      assert Config.skip_reason(config, :credo) == nil
+    end
+
+    test "skips a custom stage the profile leaves out" do
+      config =
+        @profiles ++ [custom: [[key: :house_rules, name: "House rules", command: "true"]]]
+
+      config = Config.apply_profile(config, "loop")
+
+      assert Config.skip_reason(config, :house_rules) == "not in profile :loop"
+    end
+
+    test "a profile with no stages: narrows nothing" do
+      config = Config.apply_profile(@profiles, "gate")
+
+      assert config[:profile] == :gate
+      assert Config.skip_reason(config, :dialyzer) == nil
+    end
+
+    test "an unknown profile fails the run and lists the known ones" do
+      assert_raise Mix.Error, ~r/Unknown --profile "lop".*:loop, :gate/s, fn ->
+        Config.apply_profile(@profiles, "lop")
+      end
+    end
+
+    test "an unknown profile says so when none are configured" do
+      assert_raise Mix.Error, ~r/No profiles are configured/, fn ->
+        Config.apply_profile([], "loop")
+      end
+    end
+
+    test "a malformed profiles: key fails the run" do
+      assert_raise Mix.Error, ~r/profiles: in .quality.exs must be a keyword list/, fn ->
+        Config.apply_profile([profiles: ["loop"]], "loop")
+      end
+    end
+
+    test "a malformed stages: list fails the run" do
+      assert_raise Mix.Error, ~r/stages: in profile :loop must be a list/, fn ->
+        Config.apply_profile([profiles: [loop: [stages: :credo]]], "loop")
+      end
+    end
+  end
+
+  describe "load/1 with the loop switches" do
+    test "test scope defaults to :all" do
+      assert Config.load()[:test][:scope] == :all
+      assert Config.load()[:test][:base_ref] == nil
+    end
+
+    test "--test-scope sets the scope" do
+      assert Config.load(test_scope: "changed")[:test][:scope] == :changed
+      assert Config.load(test_scope: "all")[:test][:scope] == :all
+
+      assert Config.load(test_scope: "test/**/*_test.exs")[:test][:scope] ==
+               {:glob, "test/**/*_test.exs"}
+    end
+
+    test "--test-scope does not clobber test args" do
+      config = Config.load(test_scope: "changed", test_args: ["--seed", "0"])
+
+      assert config[:test][:scope] == :changed
+      assert config[:test][:args] == ["--seed", "0"]
+    end
+
+    test "a bad --test-scope fails the run" do
+      assert_raise Mix.Error, ~r/Invalid --test-scope/, fn ->
+        Config.load(test_scope: "")
+      end
+    end
+
+    test "--until-first-failure is carried on the config" do
+      assert Config.load()[:until_first_failure] == nil
+      assert Config.load(until_first_failure: true)[:until_first_failure] == true
+    end
+  end
+
   describe "configuration merging" do
     test "deep merges nested keyword lists" do
       config = Config.load()

--- a/test/ex_quality/report_test.exs
+++ b/test/ex_quality/report_test.exs
@@ -58,6 +58,66 @@ defmodule ExQuality.ReportTest do
     end
   end
 
+  describe "how much the run covered" do
+    test "reports a full unprofiled run as such" do
+      report = Report.build([result(status: :ok)], 1)
+
+      assert report.profile == nil
+      assert report.scope == "all"
+      assert report.base_ref == nil
+    end
+
+    test "takes the scope from what the test stage actually ran" do
+      tests = result(name: "Tests", meta: %{scope: "changed", files: 3, base_ref: "origin/main"})
+
+      report = Report.build([tests], 1, profile: :loop)
+
+      assert report.profile == "loop"
+      assert report.scope == "changed"
+      assert report.base_ref == "origin/main"
+    end
+
+    test "falls back to the requested scope when the test stage did not run" do
+      results = [Stage.skipped("Tests", "not in profile :lint")]
+
+      assert Report.build(results, 1, test: [scope: :changed]).scope == "changed"
+    end
+
+    test "merges a stage's meta into its own object" do
+      tests =
+        result(
+          name: "Tests",
+          meta: %{
+            scope: "changed",
+            files: 1,
+            coverage: "skipped",
+            test_files: ["test/a_test.exs"]
+          }
+        )
+
+      [stage] = Report.build([tests], 1).stages
+
+      assert stage.scope == "changed"
+      assert stage.files == 1
+      assert stage.coverage == "skipped"
+      assert stage.test_files == ["test/a_test.exs"]
+      # The keys every stage has are still there.
+      assert stage.status == "ok"
+      assert stage.duration_ms == 42
+    end
+
+    test "encodes the whole thing" do
+      tests = result(name: "Tests", meta: %{scope: "changed", files: 2})
+
+      json = [tests] |> Report.build(1, profile: :loop) |> Report.encode!() |> Jason.decode!()
+
+      assert json["profile"] == "loop"
+      assert json["scope"] == "changed"
+      assert json["base_ref"] == nil
+      assert hd(json["stages"])["files"] == 2
+    end
+  end
+
   describe "findings" do
     test "are reported per stage" do
       finding = %Finding{

--- a/test/ex_quality/scope_test.exs
+++ b/test/ex_quality/scope_test.exs
@@ -1,0 +1,270 @@
+defmodule ExQuality.ScopeTest do
+  # Not async: the `:changed` cases run git against a working tree, and the
+  # working directory is per-node rather than per-process.
+  use ExUnit.Case, async: false
+
+  alias ExQuality.Scope
+
+  doctest ExQuality.Scope
+
+  # A real repository rather than a stubbed git: the point of `:changed` is that
+  # it reads uncommitted and untracked work, and a stub that returns whatever the
+  # test wants proves nothing about which git commands would actually say so.
+  setup context do
+    if context[:repo] do
+      repo =
+        Path.join(System.tmp_dir!(), "ex_quality_scope_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(repo)
+      on_exit(fn -> File.rm_rf!(repo) end)
+
+      git(repo, ["init", "--initial-branch", "main"])
+      git(repo, ["config", "user.email", "test@example.com"])
+      git(repo, ["config", "user.name", "Test"])
+
+      write(repo, "mix.exs", "# project\n")
+      write(repo, "lib/kept.ex", "defmodule Kept do\nend\n")
+      write(repo, "test/kept_test.exs", "defmodule KeptTest do\nend\n")
+      git(repo, ["add", "."])
+      git(repo, ["commit", "-m", "initial"])
+
+      %{repo: repo}
+    else
+      :ok
+    end
+  end
+
+  defp git(repo, args) do
+    {output, code} = System.cmd("git", args, cd: repo, stderr_to_stdout: true)
+    assert code == 0, "git #{Enum.join(args, " ")} failed: #{output}"
+    output
+  end
+
+  defp write(repo, path, contents) do
+    full = Path.join(repo, path)
+    File.mkdir_p!(Path.dirname(full))
+    File.write!(full, contents)
+  end
+
+  # The resolver reads the working tree, so it has to run in it.
+  defp in_repo(repo, fun) do
+    cwd = File.cwd!()
+    File.cd!(repo)
+
+    try do
+      fun.()
+    after
+      File.cd!(cwd)
+    end
+  end
+
+  describe "parse/1" do
+    test "accepts both the atom and the string spelling" do
+      assert Scope.parse(:all) == {:ok, :all}
+      assert Scope.parse("all") == {:ok, :all}
+      assert Scope.parse(:changed) == {:ok, :changed}
+      assert Scope.parse("changed") == {:ok, :changed}
+    end
+
+    test "treats any other string as a glob" do
+      assert Scope.parse("test/unit/**/*_test.exs") == {:ok, {:glob, "test/unit/**/*_test.exs"}}
+    end
+
+    test "round-trips an already-parsed glob" do
+      assert Scope.parse({:glob, "test/**"}) == {:ok, {:glob, "test/**"}}
+    end
+
+    test "rejects anything else" do
+      assert {:error, message} = Scope.parse(:nearly)
+      assert message =~ "must be :all, :changed or a glob string"
+
+      assert {:error, _message} = Scope.parse("")
+    end
+  end
+
+  describe "from_config/1" do
+    test "defaults to :all" do
+      assert Scope.from_config([]) == :all
+      assert Scope.from_config(test: []) == :all
+    end
+
+    test "raises rather than falling back on a bad value" do
+      assert_raise Mix.Error, ~r/must be :all, :changed or a glob string/, fn ->
+        Scope.from_config(test: [scope: :chagned])
+      end
+    end
+  end
+
+  describe "resolve/2 with :all" do
+    test "resolves to the whole suite and takes no base ref" do
+      assert Scope.resolve(:all) == %{
+               scope: :all,
+               requested_scope: :all,
+               files: :all,
+               base_ref: nil,
+               fallback_reason: nil
+             }
+    end
+  end
+
+  describe "resolve/2 with a glob" do
+    test "resolves to the matching test files" do
+      resolved = Scope.resolve({:glob, "test/ex_quality/stages/*_test.exs"})
+
+      assert resolved.scope == {:glob, "test/ex_quality/stages/*_test.exs"}
+      assert "test/ex_quality/stages/credo_test.exs" in resolved.files
+      assert resolved.fallback_reason == nil
+    end
+
+    test "ignores matches that are not test files" do
+      resolved = Scope.resolve({:glob, "lib/ex_quality/*.ex"})
+
+      assert resolved.files == :all
+      assert resolved.fallback_reason == "the glob matched no test files"
+    end
+
+    test "falls back to the full suite when nothing matches" do
+      resolved = Scope.resolve({:glob, "test/nothing/**/*_test.exs"})
+
+      assert resolved.scope == :all
+      assert resolved.requested_scope == {:glob, "test/nothing/**/*_test.exs"}
+      assert resolved.files == :all
+      assert resolved.fallback_reason == "the glob matched no test files"
+    end
+  end
+
+  describe "test_files/1" do
+    test "maps a source file to the test file beside it" do
+      assert Scope.test_files(["lib/ex_quality/scope.ex"]) == ["test/ex_quality/scope_test.exs"]
+    end
+
+    test "maps an umbrella source file under its own app" do
+      # Nothing exists at that path here, so this asserts the mapping through the
+      # only observable it has: a mapped path that does not exist is dropped.
+      assert Scope.test_files(["apps/web/lib/web/user.ex"]) == []
+    end
+
+    test "keeps a changed test file as itself" do
+      assert Scope.test_files(["test/ex_quality/scope_test.exs"]) == [
+               "test/ex_quality/scope_test.exs"
+             ]
+    end
+
+    test "drops files with no test to run" do
+      assert Scope.test_files(["mix.exs", "README.md", ".quality.exs"]) == []
+    end
+
+    test "drops a source file whose test file does not exist" do
+      assert Scope.test_files(["lib/ex_quality/no_such_module.ex"]) == []
+    end
+
+    test "deduplicates a source file changed alongside its own test" do
+      assert Scope.test_files(["lib/ex_quality/scope.ex", "test/ex_quality/scope_test.exs"]) == [
+               "test/ex_quality/scope_test.exs"
+             ]
+    end
+  end
+
+  describe "resolve/2 with :changed" do
+    @tag :repo
+    test "includes uncommitted changes to a source file", %{repo: repo} do
+      write(repo, "lib/kept.ex", "defmodule Kept do\n  def added, do: :ok\nend\n")
+
+      in_repo(repo, fn ->
+        resolved = Scope.resolve(:changed, base_ref: "main")
+
+        assert resolved.scope == :changed
+        assert resolved.files == ["test/kept_test.exs"]
+        assert resolved.base_ref == "main"
+        assert resolved.fallback_reason == nil
+      end)
+    end
+
+    @tag :repo
+    test "includes untracked test files", %{repo: repo} do
+      write(repo, "test/brand_new_test.exs", "defmodule BrandNewTest do\nend\n")
+
+      in_repo(repo, fn ->
+        assert Scope.resolve(:changed, base_ref: "main").files == ["test/brand_new_test.exs"]
+      end)
+    end
+
+    @tag :repo
+    test "includes committed work on a branch", %{repo: repo} do
+      git(repo, ["checkout", "-b", "feature"])
+      write(repo, "lib/kept.ex", "defmodule Kept do\n  def committed, do: :ok\nend\n")
+      git(repo, ["add", "."])
+      git(repo, ["commit", "-m", "change"])
+
+      in_repo(repo, fn ->
+        assert Scope.resolve(:changed, base_ref: "main").files == ["test/kept_test.exs"]
+      end)
+    end
+
+    @tag :repo
+    test "runs the full suite when nothing has changed", %{repo: repo} do
+      in_repo(repo, fn ->
+        resolved = Scope.resolve(:changed, base_ref: "main")
+
+        assert resolved.scope == :all
+        assert resolved.requested_scope == :changed
+        assert resolved.files == :all
+        assert resolved.fallback_reason == "no test files map to the changed files"
+      end)
+    end
+
+    @tag :repo
+    test "runs the full suite when the change maps to no tests", %{repo: repo} do
+      write(repo, "mix.exs", "# changed project\n")
+
+      in_repo(repo, fn ->
+        resolved = Scope.resolve(:changed, base_ref: "main")
+
+        assert resolved.files == :all
+        assert resolved.fallback_reason == "no test files map to the changed files"
+      end)
+    end
+
+    @tag :repo
+    test "ignores a deleted source file", %{repo: repo} do
+      File.rm!(Path.join(repo, "lib/kept.ex"))
+
+      in_repo(repo, fn ->
+        assert Scope.resolve(:changed, base_ref: "main").files == :all
+      end)
+    end
+
+    @tag :repo
+    test "runs the full suite when the base ref does not exist", %{repo: repo} do
+      write(repo, "lib/kept.ex", "defmodule Kept do\n  def added, do: :ok\nend\n")
+
+      in_repo(repo, fn ->
+        resolved = Scope.resolve(:changed, base_ref: "origin/nope")
+
+        assert resolved.scope == :all
+        assert resolved.requested_scope == :changed
+        assert resolved.fallback_reason =~ "not a ref in a git repository here"
+      end)
+    end
+
+    test "runs the full suite when there is no base ref to compare against" do
+      resolved = Scope.resolve(:changed, base_ref: nil)
+
+      # The library's own repository has a default branch, so this only asserts
+      # the shape of the answer when there is nothing to diff against.
+      assert resolved.scope in [:all, :changed]
+
+      no_ref = Scope.resolve(:changed, base_ref: "")
+      assert no_ref.files == :all
+      assert no_ref.fallback_reason != nil
+    end
+  end
+
+  describe "describe/1" do
+    test "renders each scope as the report and the console show it" do
+      assert Scope.describe(:all) == "all"
+      assert Scope.describe(:changed) == "changed"
+      assert Scope.describe({:glob, "test/unit/**"}) == "test/unit/**"
+    end
+  end
+end

--- a/test/ex_quality/stages/test_test.exs
+++ b/test/ex_quality/stages/test_test.exs
@@ -917,6 +917,91 @@ defmodule ExQuality.Stages.TestTest do
     end
   end
 
+  describe "run/1 - scoped runs" do
+    # A glob over files that really exist, so the scope resolves without a git
+    # working tree to set up. `:changed` resolution is covered in ScopeTest.
+    @glob "test/ex_quality/stages/co*_test.exs"
+    @scoped_files [
+      "test/ex_quality/stages/command_test.exs",
+      "test/ex_quality/stages/compile_test.exs"
+    ]
+
+    setup do
+      ExQuality.Tools |> stub(:available?, fn _tool -> true end)
+
+      :ok
+    end
+
+    test "runs only the test files in scope" do
+      System
+      |> expect(:cmd, fn "mix", args, _opts ->
+        assert args == ["test" | @scoped_files]
+        {"2 tests, 0 failures\n", 0}
+      end)
+
+      result = Test.run(test: [scope: @glob])
+
+      assert result.status == :ok
+      assert result.meta.scope == @glob
+      assert result.meta.files == 2
+      assert result.meta.test_files == @scoped_files
+    end
+
+    test "never measures coverage on a scoped run, even with coveralls available" do
+      System
+      |> expect(:cmd, fn "mix", ["test" | _files], _opts -> {"2 tests, 0 failures\n", 0} end)
+
+      result = Test.run(test: [scope: @glob, coverage: true])
+
+      assert result.meta.coverage == "skipped"
+      assert result.meta.coverage_reason == "not measured on a scoped run"
+      refute Map.has_key?(result.stats, :coverage)
+    end
+
+    test "says in the summary what it did and did not cover" do
+      System
+      |> expect(:cmd, fn "mix", ["test" | _files], _opts -> {"2 tests, 0 failures\n", 0} end)
+
+      result = Test.run(test: [scope: @glob])
+
+      assert result.summary == "2 of 2 passed (scope #{@glob}, 2 files, no coverage)"
+    end
+
+    test "passes configured test args ahead of the paths" do
+      System
+      |> expect(:cmd, fn "mix", args, _opts ->
+        assert args == ["test", "--seed", "0"] ++ @scoped_files
+        {"2 tests, 0 failures\n", 0}
+      end)
+
+      Test.run(test: [scope: @glob, args: ["--seed", "0"]])
+    end
+
+    test "runs the full suite when the scope resolves to nothing" do
+      System
+      |> expect(:cmd, fn "mix", ["coveralls"], _opts -> {"2 tests, 0 failures\n", 0} end)
+
+      result = Test.run(test: [scope: "test/nowhere/**/*_test.exs"])
+
+      assert result.meta.scope == "all"
+      assert result.meta.requested_scope == "test/nowhere/**/*_test.exs"
+      assert result.meta.fallback_reason == "the glob matched no test files"
+      refute Map.has_key?(result.meta, :coverage)
+
+      assert result.summary =~ "fell back to the full suite"
+    end
+
+    test "an unscoped run reports the scope it ran at" do
+      System
+      |> expect(:cmd, fn "mix", ["coveralls"], _opts -> {"2 tests, 0 failures\n", 0} end)
+
+      result = Test.run([])
+
+      assert result.meta == %{scope: "all"}
+      assert result.summary == "2 of 2 passed"
+    end
+  end
+
   defp umbrella_export_output do
     """
     ==> one

--- a/test/integration/quality_test.exs
+++ b/test/integration/quality_test.exs
@@ -160,6 +160,35 @@ defmodule Integration.ExQualityTest do
       assert output =~ "○ House rules: skipped (--skip house_rules)"
       refute output =~ "✓ House rules"
     end
+
+    test "--profile runs the stages it lists and reports the rest as skipped" do
+      fixture_path = copy_fixture("with_config")
+
+      {_output, 0} = System.cmd("mix", ["deps.get"], cd: fixture_path, stderr_to_stdout: true)
+
+      {output, exit_code} = run_quality(fixture_path, ["--profile", "loop"])
+
+      assert exit_code == 0, "Expected success. Output:\n#{output}"
+
+      assert output =~ "✓ Credo:"
+      # Everything the profile leaves out says so, built-in and custom alike, so
+      # a fast run is never a run with quiet gaps in it.
+      assert output =~ "○ Tests: skipped (not in profile :loop)"
+      assert output =~ "○ House rules: skipped (not in profile :loop)"
+      refute output =~ "✓ House rules"
+    end
+
+    test "an unknown --profile fails the run rather than falling back" do
+      fixture_path = copy_fixture("with_config")
+
+      {_output, 0} = System.cmd("mix", ["deps.get"], cd: fixture_path, stderr_to_stdout: true)
+
+      {output, exit_code} = run_quality(fixture_path, ["--profile", "lop"])
+
+      assert exit_code == 1, "Expected failure. Output:\n#{output}"
+      assert output =~ ~s(Unknown --profile "lop")
+      assert output =~ ":loop, :gate"
+    end
   end
 
   describe "umbrella fixture" do

--- a/test/mix/tasks/quality_test.exs
+++ b/test/mix/tasks/quality_test.exs
@@ -777,6 +777,149 @@ defmodule Mix.Tasks.QualityTest do
 
   # The runs above fail on purpose; the report is the thing under test, not
   # the exception Mix raises afterwards.
+  describe "an inner loop rather than a gate" do
+    setup do
+      ExQuality.Tools
+      |> stub(:detect, fn ->
+        %{
+          credo: true,
+          dialyzer: false,
+          doctor: false,
+          gettext: false,
+          coverage: false,
+          audit: false,
+          sobelow: false
+        }
+      end)
+      |> stub(:available?, fn tool -> tool == :credo end)
+
+      :ok
+    end
+
+    defp record_commands do
+      test_pid = self()
+
+      System
+      |> stub(:cmd, fn cmd, args, _opts ->
+        send(test_pid, {:ran, args})
+
+        case args do
+          ["credo" | _] -> {Jason.encode!(%{issues: []}), 0}
+          ["test" | _] -> {"1 tests, 0 failures\n", 0}
+          _other when cmd == "git" -> {"", 1}
+          _other -> {"", 0}
+        end
+      end)
+    end
+
+    defp ran_commands do
+      Enum.reverse(drain_commands([]))
+    end
+
+    defp drain_commands(acc) do
+      receive do
+        {:ran, args} -> drain_commands([args | acc])
+      after
+        0 -> acc
+      end
+    end
+
+    test "--profile skips the stages the profile leaves out" do
+      ExQuality.Config
+      |> stub(:load, fn opts ->
+        ExQuality.Config.apply_profile(
+          [profiles: [loop: [stages: [:format, :credo]]]],
+          opts[:profile]
+        )
+      end)
+
+      record_commands()
+
+      captured = capture_io(fn -> Quality.run(["--profile", "loop", "--skip-dialyzer"]) end)
+
+      assert captured =~ "○ Tests: skipped (not in profile :loop)"
+      assert captured =~ "○ Compile: skipped (not in profile :loop)"
+      refute Enum.any?(ran_commands(), &match?(["test" | _], &1))
+    end
+
+    test "--test-scope changed narrows the suite the run pays for" do
+      record_commands()
+
+      capture_io(fn ->
+        run_failing(["--test-scope", "test/ex_quality/scope_test.exs", "--skip-credo"])
+      end)
+
+      assert ["test", "test/ex_quality/scope_test.exs"] in ran_commands()
+    end
+
+    test "--until-first-failure stops at the first failing stage, cheapest first" do
+      test_pid = self()
+
+      System
+      |> stub(:cmd, fn _cmd, args, _opts ->
+        send(test_pid, {:ran, args})
+
+        case args do
+          ["deps.unlock", "--check-unused"] -> {"Unused deps: :leftover\n", 1}
+          ["credo" | _] -> {Jason.encode!(%{issues: []}), 0}
+          ["test" | _] -> {"1 tests, 0 failures\n", 0}
+          _other -> {"", 0}
+        end
+      end)
+
+      captured = capture_io(fn -> run_failing(["--until-first-failure"]) end)
+
+      # Dependencies is the cheapest stage after the two that have to go first,
+      # so credo and the suite are never paid for.
+      commands = ran_commands()
+
+      refute Enum.any?(commands, &match?(["test" | _], &1))
+      refute Enum.any?(commands, &match?(["credo" | _], &1))
+
+      assert captured =~ "○ Tests: skipped (--until-first-failure)"
+      assert captured =~ "○ Credo: skipped (--until-first-failure)"
+    end
+
+    test "--until-first-failure runs everything when nothing fails" do
+      record_commands()
+
+      captured = capture_io(fn -> Quality.run(["--until-first-failure"]) end)
+
+      commands = ran_commands()
+
+      assert Enum.any?(commands, &match?(["test" | _], &1))
+      assert Enum.any?(commands, &match?(["credo" | _], &1))
+      assert captured =~ "✓ All quality checks passed!"
+    end
+
+    test "--report - puts the report on stdout and the human stream on stderr" do
+      record_commands()
+
+      captured = capture_io(fn -> Quality.run(["--report", "-"]) end)
+
+      report = Jason.decode!(captured)
+
+      assert report["status"] == "ok"
+      assert report["scope"] == "all"
+      assert report["profile"] == nil
+    end
+
+    test "a scoped run says so in the report root and on the Tests stage" do
+      record_commands()
+
+      captured =
+        capture_io(fn -> Quality.run(["--report", "-", "--test-scope", "test/*_test.exs"]) end)
+
+      report = Jason.decode!(captured)
+      tests = Enum.find(report["stages"], &(&1["name"] == "Tests"))
+
+      assert report["scope"] == "test/*_test.exs"
+      assert tests["scope"] == "test/*_test.exs"
+      assert tests["coverage"] == "skipped"
+      assert tests["test_files"] == ["test/ex_quality_test.exs"]
+    end
+  end
+
   defp run_failing(args) do
     Quality.run(args)
   rescue

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -8,6 +8,7 @@ findings carrying `file:line`.
 
 | Situation | Command |
 |---|---|
+| Between edits, many times | `mix quality --test-scope changed` |
 | After editing code, iterating | `mix quality --quick` |
 | Before committing, opening a PR, or declaring work done | `mix quality` |
 | You need to route on *which* stage failed | `mix quality --report .quality.json` |
@@ -16,6 +17,38 @@ findings carrying `file:line`.
 `--quick` skips Dialyzer and coverage enforcement. Everything else, tests
 included, still runs. Use it while working; never use it as the final check
 before reporting work complete.
+
+## The inner loop
+
+`--quick` narrows *which checks run*. It still runs every test, and on a large
+suite the tests are most of the wall clock, so `--quick` between edits is not
+much cheaper than a full run.
+
+To narrow *how much code* the checks run over:
+
+```bash
+mix quality --test-scope changed        # only the tests covering your edits
+mix quality --until-first-failure       # stop at the first thing to fix
+```
+
+`--test-scope changed` maps the files you have changed, committed or not, to the
+test files covering them (`lib/foo/bar.ex` to `test/foo/bar_test.exs`; in an
+umbrella, under the same app). A scope that resolves to no test files runs the
+whole suite rather than reporting a green run of nothing.
+
+**A scoped green is not a full green.** Coverage is not measured, and Dialyzer
+still sees the whole project. Run a full `mix quality` before reporting work
+complete, and never treat a scoped run as the final check.
+
+If the project's `.quality.exs` declares `profiles:`, use the one it names
+instead of assembling flags yourself:
+
+```bash
+mix quality --profile loop
+```
+
+An unknown profile name fails the run rather than silently running everything, so
+a name that works is a name the project chose.
 
 ## Never truncate the output
 
@@ -118,6 +151,9 @@ a red run because it removes the signal:
   pass.
 - **Do not weaken a check** (`credo: [strict: false]`,
   `compile: [warnings_as_errors: false]`) in response to it failing.
+- **Do not use `--test-scope` or a profile to get past a failing stage**, and do
+  not report work complete on a scoped run. Narrowing scope is for iterating, not
+  for the final check.
 
 If a finding really is wrong for this project, say so and let the user decide.
 Report the failure rather than removing the thing that reported it.
@@ -130,7 +166,20 @@ specific stages programmatically, read a report instead of parsing the console:
 ```bash
 mix quality --report .quality.json   # human output on stdout, report to a file
 mix quality --format json            # report on stdout, human output on stderr
+mix quality --report -               # the same as --format json
 ```
+
+The root of the report says how much the run covered:
+
+```json
+{"status": "ok", "profile": "loop", "scope": "changed", "base_ref": "origin/main"}
+```
+
+`scope` is `"all"` for a full run. **Check it before treating a green run as
+evidence about the whole project**, and never lower a recorded coverage number or
+move a baseline on a run whose `scope` is not `"all"` - a scoped run does not
+measure coverage at all, and the Tests stage reports `"coverage": "skipped"`
+rather than a number.
 
 Every stage carries the same keys whatever its status:
 


### PR DESCRIPTION
`mix quality` is a good pre-push gate and a bad inner loop, and an agent needs both. This adds the second without weakening the first.

Measured, not guessed. A large umbrella that adopted this library ran a controlled A/B of agentic development: a control branch using individual check scripts, against a branch using this library. The ex_quality arm lost both workloads, at 1.97x and 1.43x the wall clock, and the per-command accounting says model time was not the difference. It was seven `mix quality` runs averaging 61.7s, of which the suite was 68%. Both arms could run one test file in about 3s; only one of them had a reason to.

`--quick` does not address this, and it is worth being precise about why: it removes dialyzer and the coverage threshold and still runs every test, which against that split is 10% of the cost. The general statement is that every flag this library had narrows *stages*, and the expensive question is over how much *code*.

`test: [scope: :changed]`, or `--test-scope changed`, runs only the test files covering what changed. Changed files are resolved against the merge base with the repository's default branch, including uncommitted and untracked work: an agent mid-task has everything uncommitted, so a diff that reads only committed history would report no changes on exactly the runs this exists for. `lib/foo/bar.ex` maps to `test/foo/bar_test.exs`, in an umbrella under the same app, and a changed test file is itself.

Two rules keep a scoped green readable. A scope that resolves to no test files runs the whole suite, because that is the one failure mode that would make this worse than not having it - exit 0, `"status": "ok"`, nothing run, failing in the safe-looking direction. And coverage on a scoped run is absent rather than lower: it is reported as `skipped` with a reason and never as a number, since a percentage over a subset is not a smaller truth but a different one, and an adopting project that lowers a recorded figure on a green run would corrupt it against a run that never measured.

The report carries `profile`, `scope` and `base_ref` at the root and repeats them on the Tests stage with the files it ran. `status` alone does not say what a run is evidence for, and this is what lets anything that ratchets a number or moves a baseline refuse the narrow one. `scope` is the scope achieved, not the one requested, so a caller checking `scope == "all"` never has to reason about fallbacks.

Profiles are the adoption half, which is the actual bottleneck: a fast path nobody invokes is worth nothing. `profiles:` in `.quality.exs` names bundles, `--profile loop` selects one, and a `stages:` allow-list reports everything else as skipped naming the profile. An unknown name fails the run, because falling back to "run everything" would turn a typo into a slow green and falling back to the profile's intent would turn one into a fast green over nothing.

`--until-first-failure` runs one stage at a time, cheapest first, stopping at the first failure: an iterating caller needs the next thing to fix, not a full battery report, and today a run with a formatting error still pays for the suite before saying so. The existing stage order was never cost-ordered, because the analysis phase runs in parallel and so never needed one, so the order is stated rather than derived. This is what made Format, Compile and Tests skippable; an unprofiled run with no `--skip` still runs all three.

`--report -` writes the report to stdout, as `--format json` does rather than interleaving JSON into the human stream. Agents were parsing terminal text because a file path is one more step.

Scope: :changed is deliberately not the default for a profile that does not name it. Convenience argues for it and the silent-scoped-green risk argues against, and the risk wins.

Incremental or scoped dialyzer is out of scope: real, and a much harder problem, since the PLT is whole-project by construction.