### PR TITLE
Brings the docs and the package description up to the loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # ExQuality
 
-Runs an Elixir project's quality tools in parallel and reports the run as a
-fixed set of stages, each with a status, a one-line summary, and findings that
-carry a `file:line`.
+Runs an Elixir project's quality tools in parallel and reports the run as one
+stage per tool, each with a status, a one-line summary, and findings that carry
+a `file:line`.
 
 ```
 mix quality
@@ -89,24 +89,31 @@ mix quality --quick                # while coding
 mix quality                        # before committing, and in CI
 ```
 
-Quick mode skips Dialyzer and coverage enforcement, the two slow stages. Tests
-still run, and everything else is unchanged. Full mode runs every enabled stage.
+Full mode runs every enabled stage. Quick mode drops Dialyzer and the coverage
+threshold, the two slow stages - but it still runs every test, and on a large
+suite the tests are most of the wall clock. That is the difference between the
+first two lines above: `--quick` narrows *which checks run*, and `--test-scope`
+narrows *how much code they run over*, which is the expensive question.
 
-`--test-scope changed` is the one that narrows the tests, which on a large suite
-is most of the wall clock. It runs only the test files covering the code you have
-changed, committed or not, and falls back to the whole suite if that maps to
-nothing: a green run of nothing is worse than a slow one. Coverage on a scoped run
-is reported as skipped rather than as a percentage over a subset.
+`--test-scope changed` runs only the test files covering the code you have
+changed, committed or not. Two rules keep the result readable:
 
-A project can name a bundle of those settings in `.quality.exs` so its docs and
-its agents point at one word:
+- **A scope that resolves to no test files runs the whole suite.** A green run of
+  nothing is worse than a slow one, because it fails in the safe-looking
+  direction.
+- **Coverage is reported as skipped, never as a number.** A percentage over a
+  subset of the suite is not a smaller truth, it is a different one.
+
+A project can name a bundle of settings in `.quality.exs`, so its docs and its
+agents point at one word instead of a flag list:
 
 ```elixir
 profiles: [loop: [stages: [:format, :compile, :credo], test: [scope: :changed]]]
 ```
 
 ```bash
-mix quality --profile loop
+mix quality --profile loop            # the bundle above
+mix quality --until-first-failure     # stop at the first thing to fix
 ```
 
 See [Configuration](docs/configuration.md#test-scope).
@@ -147,6 +154,7 @@ another - asks for a report instead of scraping the console:
 ```bash
 mix quality --report .quality.json   # human output on stdout, report to a file
 mix quality --format json            # report on stdout, human output on stderr
+mix quality --report -               # the same, spelled the way a pipe reads
 ```
 
 ```json
@@ -154,6 +162,9 @@ mix quality --format json            # report on stdout, human output on stderr
   "status": "error",
   "version": "0.6.0",
   "duration_ms": 5014,
+  "profile": null,
+  "scope": "all",
+  "base_ref": null,
   "stages": [
     {
       "name": "Dialyzer",
@@ -184,21 +195,31 @@ mix quality --format json            # report on stdout, human output on stderr
 
 Every stage carries the same keys whatever its status, so a consumer reads one
 field rather than branching. The report is built from the same results the
-human output is rendered from, so the two can never disagree. Full schema in
-[docs/reports.md](docs/reports.md).
+human output is rendered from, so the two can never disagree.
+
+`scope` says how much of the suite the run covered, and is what lets anything
+that ratchets a number, moves a baseline or gates a merge refuse to move on a
+narrow run: a green run over three test files and a green full run are different
+claims. Full schema in [docs/reports.md](docs/reports.md).
 
 ## Working with a coding agent
 
 ExQuality ships a [`usage-rules.md`](usage-rules.md) for AI coding assistants,
 readable by [usage_rules](https://hex.pm/packages/usage_rules). It tells an
-agent which mode to run, how to read a failure, not to truncate the output, and
-which fixes are never acceptable - lowering a coverage threshold, adding a
-`.sobelow-conf` ignore - because a tool silencing its own findings is a
-regression dressed as a pass.
+agent which command to run for which situation, how to read a failure, not to
+truncate the output, and which fixes are never acceptable - lowering a coverage
+threshold, adding a `.sobelow-conf` ignore - because a tool silencing its own
+findings is a regression dressed as a pass.
 
-The properties above are what make an agent loop cheap: a passing run costs an
-agent nine lines of context instead of several tool reports, and a failing one
-gives it `file:line` targets without a second command.
+Two things make an agent loop cheap, and they pull in opposite directions. The
+output properties above are one: a passing run costs nine lines of context
+instead of several tool reports, and a failing one gives `file:line` targets
+without a second command. The other is that the run has to be quick enough to be
+worth repeating. An aggregate command that always runs the full suite is one an
+agent will either invoke and pay for, or quietly stop invoking - both worse than
+the individual test runs it would have reached for otherwise. `--test-scope
+changed` is the answer to that, and `scope` in the report is how the full gate
+stays distinguishable from it.
 
 ## Documentation
 

--- a/lib/ex_quality.ex
+++ b/lib/ex_quality.ex
@@ -7,11 +7,14 @@ defmodule ExQuality do
 
   ## Quick Start
 
-      # Run all quality checks
+      # Everything: the gate, before a commit and in CI
       mix quality
 
-      # Quick mode (skip slow checks like dialyzer)
+      # Quick mode: skips dialyzer and coverage enforcement
       mix quality --quick
+
+      # The inner loop: only the tests covering what changed
+      mix quality --test-scope changed
 
   ## Features
 
@@ -20,7 +23,10 @@ defmodule ExQuality do
   - **Streaming output** - See results as each stage completes
   - **Auto-detection** - Enables stages based on installed dependencies
   - **Actionable feedback** - Shows file:line references for issues
-  - **Configurable** - Customize via `.quality.exs`
+  - **Scoped runs** - Narrows *how much code* a run covers, not just which
+    checks it runs, which is what makes a between-edits loop affordable. See
+    `ExQuality.Scope`
+  - **Configurable** - Customize via `.quality.exs`, including named profiles
   - **LLM-friendly** - Includes `usage-rules.md` for AI assistants
 
   ## Supported Quality Checks
@@ -31,7 +37,12 @@ defmodule ExQuality do
   - Dialyzer (type checking)
   - Doctor (documentation coverage)
   - Gettext (translation completeness)
+  - Sobelow (security analysis)
+  - Dependencies (unused deps and security audit)
   - Tests (with optional coverage via excoveralls)
+
+  A project's own checks run as stages of the same run, declared under `custom:`
+  in `.quality.exs`. See `ExQuality.Custom`.
 
   See `Mix.Tasks.Quality` for detailed usage information.
   """

--- a/lib/mix/tasks/quality.ex
+++ b/lib/mix/tasks/quality.ex
@@ -13,6 +13,9 @@ defmodule Mix.Tasks.Quality do
   2. **Compile** - Compiles dev + test environments in parallel
   3. **Analysis** - Runs enabled checks in parallel (credo, dialyzer, doctor, tests)
 
+  `--until-first-failure` replaces all three with one sequential pass, cheapest
+  stage first, stopping at the first failure. See "An inner loop" below.
+
   ## Usage
 
       mix quality
@@ -146,10 +149,15 @@ defmodule Mix.Tasks.Quality do
 
       mix quality --format json           # report on stdout, human on stderr
       mix quality --report .quality.json  # human on stdout, report to a file
+      mix quality --report -              # the same as --format json
 
-  `--report` is usually the more useful of the two, because it leaves the
-  human stream intact. Both can be given at once. See `ExQuality.Report` for
-  the shape.
+  `--report PATH` is usually the most useful, because it leaves the human
+  stream intact, and it can be given alongside `--format json`.
+
+  The root of the report carries `profile`, `scope` and `base_ref`, because
+  `status` alone does not say what a run is evidence for: a green run over three
+  test files and a green full run are different claims. See `ExQuality.Report`
+  for the shape.
 
   ## Dialyzer PLT
 

--- a/mix.exs
+++ b/mix.exs
@@ -49,9 +49,8 @@ defmodule ExQuality.MixProject do
 
   defp description do
     "Elixir code quality checker. Runs format, compile, Credo, Dialyzer, " <>
-      "coverage, Sobelow and mix_audit in parallel from one mix task, and " <>
-      "reports findings with file:line plus a JSON report for CI, scripts " <>
-      "and AI coding agents. Umbrella-aware."
+      "coverage, Sobelow and mix_audit in parallel from one mix task. " <>
+      "Findings with file:line, a JSON report, scoped runs. Umbrella-aware."
   end
 
   defp package do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -33,12 +33,27 @@ mix quality --until-first-failure       # stop at the first thing to fix
 
 `--test-scope changed` maps the files you have changed, committed or not, to the
 test files covering them (`lib/foo/bar.ex` to `test/foo/bar_test.exs`; in an
-umbrella, under the same app). A scope that resolves to no test files runs the
-whole suite rather than reporting a green run of nothing.
+umbrella, under the same app). The Tests line says what it ran:
+
+```
+✓ Tests: 12 of 12 passed (scope changed, 3 files vs origin/main, no coverage) (2.8s)
+```
+
+A scope that resolves to no test files runs the whole suite rather than reporting
+a green run of nothing, and says so instead of quietly passing:
+
+```
+✓ Tests: 4,180 of 4,180 passed (scope changed fell back to the full suite: no test files map to the changed files)
+```
 
 **A scoped green is not a full green.** Coverage is not measured, and Dialyzer
 still sees the whole project. Run a full `mix quality` before reporting work
 complete, and never treat a scoped run as the final check.
+
+With `--until-first-failure` the stages after the failure are reported as
+`○ Tests: skipped (--until-first-failure)`. Those are not missing checks and not
+something to report to the user - they are checks this run deliberately did not
+pay for. Fix the failure and run again.
 
 If the project's `.quality.exs` declares `profiles:`, use the one it names
 instead of assembling flags yourself:
@@ -53,8 +68,9 @@ a name that works is a name the project chose.
 ## Never truncate the output
 
 ```bash
-mix quality              # correct
-mix quality --quick      # correct
+mix quality                        # correct
+mix quality --quick                # correct
+mix quality --test-scope changed   # correct
 
 mix quality | tail -50   # wrong
 mix quality 2>&1 | head  # wrong
@@ -82,6 +98,11 @@ do not see was not silently fine - it was not considered at all.
 **Read the `○` lines.** `○ Credo: skipped (:credo not installed)` means the
 project has no static analysis, and a green run proves less than it looks like
 it does. That is worth telling the user, not passing over.
+
+The reason distinguishes the two kinds. `:credo not installed` or `disabled in
+.quality.exs` is a gap in what the project checks at all. `--quick`,
+`not in profile :loop` and `--until-first-failure` are gaps in *this* run,
+because you asked for a narrower one; a full `mix quality` closes them.
 
 Failures print below the summary, grouped by file:
 
@@ -216,11 +237,18 @@ on `status` and `findings`; treat `name` as a label.
 [
   credo: [strict: true],
   dialyzer: [enabled: false],
-  test: [args: ["--only", "integration"]]
+  test: [args: ["--only", "integration"]],
+  profiles: [loop: [stages: [:format, :compile, :credo], test: [scope: :changed]]]
 ]
 ```
 
-Test arguments also go after `--`: `mix quality -- --seed 0`.
+Test arguments also go after `--`: `mix quality -- --seed 0`. That is also how to
+bound a failing suite while iterating:
+`mix quality --test-scope changed -- --max-failures 3`.
+
+If the file declares `profiles:`, those names are the project's answer to "what
+should I run while iterating". Use them rather than inventing a flag combination,
+and do not add or edit one to make a run pass.
 
 Coverage and security thresholds are deliberately not configurable here. They
 are read from the tool that owns them, so there is one place to change what


### PR DESCRIPTION
A follow-up pass over the reader-facing text, now that scoped runs, profiles and `--until-first-failure` exist. Mostly gaps the feature commit left, plus two things that had already drifted.

The README's opening line said the run was reported as "a fixed set of stages", which stopped being true when custom stages landed in 0.9.0, and the JSON sample was missing the new root fields. The modes section now says why there are three rather than listing them: `--quick` narrows which checks run, `--test-scope` narrows how much code they run over, and on a large suite only the second one touches the number that matters.

The agent section had one half of the argument. Cheap output is necessary and not sufficient: an aggregate command that always runs the full suite is one an agent either pays for or quietly stops invoking, and both are worse than the individual test runs it would have reached for instead. That is what the measured A/B showed, and it is the reason `scope` is in the report
- so the fast path and the gate stay distinguishable.

usage-rules.md gains what an agent has to recognise rather than infer. What a scoped Tests line looks like, including the fallback wording, so a full suite that ran under a `changed` scope is not read as a narrow one. That `○ Tests: skipped (--until-first-failure)` is a check this run declined to pay for rather than a gap in the project, which the existing "read the ○ lines" rule would otherwise turn into a false report to the user. And `-- --max-failures 3` under configuration, since bounding a failing suite is the thing an agent actually wants from "stop early" and it already works.

The package description drops "for CI, scripts and AI coding agents", which was three audiences for one sentence, and gains "scoped runs".