### PR TITLE
Fixes hex.pm guide links, and dedupe the status printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ mix quality --profile loop            # the bundle above
 mix quality --until-first-failure     # stop at the first thing to fix
 ```
 
-See [Configuration](docs/configuration.md#test-scope).
+See [Configuration](https://hexdocs.pm/ex_quality/configuration.html#test-scope).
 
 ## Stages
 
@@ -143,7 +143,7 @@ a 30s one.
 
 Umbrella projects are first-class: tools are detected across every child app,
 findings are tagged with the app they came from, and coverage is aggregated
-across the suite. See [docs/umbrella.md](docs/umbrella.md).
+across the suite. See [Umbrella projects](https://hexdocs.pm/ex_quality/umbrella.html).
 
 ## Machine-readable reports
 
@@ -200,11 +200,11 @@ human output is rendered from, so the two can never disagree.
 `scope` says how much of the suite the run covered, and is what lets anything
 that ratchets a number, moves a baseline or gates a merge refuse to move on a
 narrow run: a green run over three test files and a green full run are different
-claims. Full schema in [docs/reports.md](docs/reports.md).
+claims. Full schema in [Reports](https://hexdocs.pm/ex_quality/reports.html).
 
 ## Working with a coding agent
 
-ExQuality ships a [`usage-rules.md`](usage-rules.md) for AI coding assistants,
+ExQuality ships a [`usage-rules.md`](https://hexdocs.pm/ex_quality/usage-rules.html) for AI coding assistants,
 readable by [usage_rules](https://hex.pm/packages/usage_rules). It tells an
 agent which command to run for which situation, how to read a failure, not to
 truncate the output, and which fixes are never acceptable - lowering a coverage
@@ -223,11 +223,11 @@ stays distinguishable from it.
 
 ## Documentation
 
-- [Configuration](docs/configuration.md) - `.quality.exs`, CLI flags, precedence
-- [Stages](docs/stages.md) - what each stage runs, reports, and how thresholds are sourced
-- [Reports](docs/reports.md) - the JSON report schema
-- [Umbrella projects](docs/umbrella.md) - detection, findings, coverage, Sobelow
-- [CI and pre-commit](docs/ci.md) - pipelines, PLT caching, hooks
+- [Configuration](https://hexdocs.pm/ex_quality/configuration.html) - `.quality.exs`, CLI flags, precedence
+- [Stages](https://hexdocs.pm/ex_quality/stages.html) - what each stage runs, reports, and how thresholds are sourced
+- [Reports](https://hexdocs.pm/ex_quality/reports.html) - the JSON report schema
+- [Umbrella projects](https://hexdocs.pm/ex_quality/umbrella.html) - detection, findings, coverage, Sobelow
+- [CI and pre-commit](https://hexdocs.pm/ex_quality/ci.html) - pipelines, PLT caching, hooks
 
 ## License
 

--- a/lib/ex_quality/printer.ex
+++ b/lib/ex_quality/printer.ex
@@ -38,16 +38,24 @@ defmodule ExQuality.Printer do
   @doc """
   Prints a stage result atomically.
 
-  Blocks until any concurrent print operation completes,
-  then prints the full result without interruption.
+  Blocks until any concurrent print operation completes, then prints the full
+  result without interruption. The sequential phases of a run print their
+  results before there is a printer to serialize against, so a result printed
+  with no printer started goes straight to the shell.
   """
   @spec print_result(ExQuality.Stage.result()) :: :ok
   def print_result(result) do
-    Agent.get_and_update(__MODULE__, fn state ->
-      # Print while holding the agent lock
-      do_print_result(result)
-      {:ok, state}
-    end)
+    case Process.whereis(__MODULE__) do
+      nil ->
+        do_print_result(result)
+
+      _pid ->
+        Agent.get_and_update(__MODULE__, fn state ->
+          # Print while holding the agent lock
+          do_print_result(result)
+          {:ok, state}
+        end)
+    end
   end
 
   @doc """
@@ -71,10 +79,18 @@ defmodule ExQuality.Printer do
     end
   end
 
+  # Colour is a second channel over the glyph, never a replacement for it: both
+  # shells run their output through `IO.ANSI.format/1`, which drops the codes
+  # when the output is not a terminal, so a CI log or a piped run still reads
+  # the status off the ✓/✗/○. `Mix.shell().error/1` already renders in red, so
+  # the failure line asks for no colour of its own.
   defp do_print_result(%{status: :ok} = result) do
-    Mix.shell().info(
-      "✓ #{result.name}: #{result.summary} (#{format_duration(result.duration_ms)})"
-    )
+    Mix.shell().info([
+      :green,
+      "✓ #{result.name}:",
+      :reset,
+      " #{result.summary} (#{format_duration(result.duration_ms)})"
+    ])
   end
 
   defp do_print_result(%{status: :error} = result) do
@@ -83,8 +99,9 @@ defmodule ExQuality.Printer do
     )
   end
 
+  # A skipped stage is context rather than a result, and dims as a whole.
   defp do_print_result(%{status: :skipped} = result) do
-    Mix.shell().info("○ #{result.name}: skipped#{skip_reason(result)}")
+    Mix.shell().info([:light_black, "○ #{result.name}: skipped#{skip_reason(result)}"])
   end
 
   defp skip_reason(%{summary: reason}) when is_binary(reason) and reason != "", do: " (#{reason})"

--- a/lib/mix/tasks/quality.ex
+++ b/lib/mix/tasks/quality.ex
@@ -294,17 +294,17 @@ defmodule Mix.Tasks.Quality do
   defp run_in_phases(config, started, reporting) do
     # Phase 1: Auto-fix (format)
     format_result = run_or_skip(config, :format, "Format", &Format.run/1)
-    display_phase_result(format_result)
+    Printer.print_result(format_result)
 
     # Phase 2: Compile (blocking gate)
     compile_result = run_or_skip(config, :compile, "Compile", &Compile.run/1)
-    display_phase_result(compile_result)
+    Printer.print_result(compile_result)
 
     if compile_result.status == :error do
       # Nothing downstream ran, and a stage that says nothing reads as a stage
       # that passed, so every one of them is reported as skipped.
       not_run = analysis_stages_not_run(config, "compile failed")
-      Enum.each(not_run, &display_phase_result/1)
+      Enum.each(not_run, &Printer.print_result/1)
 
       finish(
         [format_result, compile_result | not_run],
@@ -331,12 +331,12 @@ defmodule Mix.Tasks.Quality do
   # read yet.
   defp run_serially(config, started, reporting) do
     {stages, skipped} = serial_stages(config)
-    Enum.each(skipped, &display_phase_result/1)
+    Enum.each(skipped, &Printer.print_result/1)
 
     {ran, not_run} = run_until_failure(stages, config)
 
     stopped = Enum.map(not_run, &Stage.skipped(&1.name, "--until-first-failure"))
-    Enum.each(stopped, &display_phase_result/1)
+    Enum.each(stopped, &Printer.print_result/1)
 
     finish(skipped ++ ran ++ stopped, started, reporting, config, nil)
   end
@@ -344,7 +344,7 @@ defmodule Mix.Tasks.Quality do
   defp run_until_failure(stages, config) do
     Enum.reduce_while(stages, {[], stages}, fn stage, {ran, remaining} ->
       result = stage.run.(config)
-      display_phase_result(result)
+      Printer.print_result(result)
 
       ran = ran ++ [result]
       remaining = tl(remaining)
@@ -389,7 +389,7 @@ defmodule Mix.Tasks.Quality do
       Mix.shell().info("")
       display_failure_details(failures, reporting.device)
     else
-      Mix.shell().info("\n✓ All quality checks passed!")
+      Mix.shell().info([:green, "\n✓ All quality checks passed!"])
     end
 
     emit_report(results, System.monotonic_time(:millisecond) - started, reporting, config)
@@ -523,30 +523,6 @@ defmodule Mix.Tasks.Quality do
 
   defp stage_skip_reason(config, stage), do: Config.skip_reason(config, stage)
 
-  # Compile never skips, so this renders one status it can never be given from
-  # the compile phase; the branch is kept so every status has one renderer.
-  @dialyzer {:nowarn_function, [display_phase_result: 1, skip_reason: 1]}
-  @spec display_phase_result(ExQuality.Stage.result()) :: :ok
-  defp display_phase_result(result) do
-    case result.status do
-      :ok ->
-        Mix.shell().info(
-          "✓ #{result.name}: #{result.summary} (#{format_duration(result.duration_ms)})"
-        )
-
-      :error ->
-        Mix.shell().error(
-          "✗ #{result.name}: #{result.summary} (#{format_duration(result.duration_ms)})"
-        )
-
-      :skipped ->
-        Mix.shell().info("○ #{result.name}: skipped#{skip_reason(result)}")
-    end
-  end
-
-  defp skip_reason(%{summary: reason}) when is_binary(reason) and reason != "", do: " (#{reason})"
-  defp skip_reason(_result), do: ""
-
   defp display_failure_details(failures, device) do
     Enum.each(failures, fn failure ->
       Mix.shell().info(String.duplicate("─", 60))
@@ -567,7 +543,4 @@ defmodule Mix.Tasks.Quality do
       findings -> IO.write(device, Finding.render(findings))
     end
   end
-
-  defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
-  defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,12 @@ Mimic.copy(ExQuality.Config)
 Mimic.copy(ExQuality.Tools)
 Mimic.copy(ExQuality.Umbrella)
 
+# Status lines carry colour, which `IO.ANSI.format/1` emits or drops based on
+# whether the output is a terminal. `mix test` from a terminal leaves it on, so
+# escape codes would land in the middle of every captured line. Pin it off: the
+# assertions are about what the line says, not how it is painted.
+Application.put_env(:elixir, :ansi_enabled, false)
+
 # Start ExUnit
 # Note: Integration tests use fixture projects in fixtures/ to avoid infinite recursion.
 # They are excluded by default for faster feedback, but can be run with:


### PR DESCRIPTION
Two unrelated-but-adjacent bits of output polish.

## README guide links

The guide links on https://hex.pm/packages/ex_quality landed on raw markdown
files instead of the rendered pages. hex.pm renders the README from the
tarball and resolves relative paths against it, and `docs/` ships in `files:`,
so `docs/configuration.md` resolved to the file rather than the guide.

They are absolute HexDocs URLs now, which work from both hex.pm and GitHub.
The tradeoff is that they always point at the latest version rather than the
one being viewed. Guide-to-guide links inside `docs/` stay relative: ExDoc
resolves those correctly, and those files are not rendered on hex.pm anyway.

## One renderer for stage results, with colour

The status lines had two renderers, identical clause for clause: `Printer` for
the parallel phase and `display_phase_result/1` for the sequential one.
`Printer.print_result/1` now falls back to the shell when no printer agent is
running, which is the only thing the sequential phase needed it to do, so the
copy in the task goes away.

Colour is a second channel over the glyph, never a replacement:

- green on the tick and the stage name, summary and duration left plain, so a
  run of six passing stages does not turn the screen green
- dim on a skipped line, which is context rather than a result
- nothing new on the failure line, because `Mix.Shell.IO.error/1` already
  renders its argument in red

Both shells format through `IO.ANSI`, which drops the codes when stdout is not
a terminal, so CI logs and `--format json` runs are byte-for-byte unchanged and
no `--no-color` flag was needed.

`test_helper.exs` pins `ansi_enabled` off: `mix test` from a terminal leaves it
on, which would put escape codes in the middle of every captured line the
assertions match against.

## Verification

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo
--strict`, 521 unit tests and 22 integration tests all green.