### PR TITLE
Shows the example run in colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,29 +20,11 @@ text and inferring what is missing from them.
 
 ExQuality normalises that. One run, one stream, one shape per stage:
 
-```
-Running quality checks...
+![A mix quality run: green passing stages, dim skipped stages, and a red failing stage with its finding printed below](https://raw.githubusercontent.com/riddler/ex_quality/main/assets/example-output.svg)
 
-✓ Format: No changes needed (458ms)
-✓ Compile: dev + test compiled (warnings as errors) (325ms)
-
-Running analysis stages in parallel...
-
-○ Dialyzer: skipped (--quick)
-○ Gettext: skipped (:gettext not installed)
-○ Sobelow: skipped (:sobelow not installed)
-✓ Doctor: Passed (519ms)
-✓ Credo: No issues (775ms)
-✗ Dependencies: 1 vulnerability (1 moderate) (2.5s)
-✓ Tests: 345 of 345 passed (4.1s)
-
-────────────────────────────────────────────────────────────
-Dependencies - FAILED
-────────────────────────────────────────────────────────────
-mix.lock
-  -  [error] decimal 2.3.0: Unbounded exponent in `Decimal.new` enables
-     unauthenticated DoS (moderate severity, patched in 3.0.0) (GHSA-rhv4-8758-jx7v)
-```
+Colour is a second channel over the `✓`, `○` and `✗`, never a replacement for
+one. It is dropped when the output is not a terminal, so a CI log or a piped run
+reads exactly the same minus the paint.
 
 Three properties follow from that, and they are what the tool is for:
 

--- a/assets/example-output.svg
+++ b/assets/example-output.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="732" height="464" viewBox="0 0 732 464" role="img" aria-label="mix quality output: green passing stages, dim skipped stages, a red failing stage and its finding">
+  <rect width="732" height="464" rx="8" fill="#11151c"/>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace" font-size="13" fill="#d8dee9">
+  <text x="22" y="35"><tspan xml:space="preserve">Running quality checks...</tspan></text>
+  <text x="22" y="75"><tspan fill="#3fb950" xml:space="preserve">✓ Format:</tspan><tspan xml:space="preserve"> No changes needed (458ms)</tspan></text>
+  <text x="22" y="95"><tspan fill="#3fb950" xml:space="preserve">✓ Compile:</tspan><tspan xml:space="preserve"> dev + test compiled (warnings as errors) (325ms)</tspan></text>
+  <text x="22" y="135"><tspan xml:space="preserve">Running analysis stages in parallel...</tspan></text>
+  <text x="22" y="175"><tspan fill="#6e7681" xml:space="preserve">○ Dialyzer: skipped (--quick)</tspan></text>
+  <text x="22" y="195"><tspan fill="#6e7681" xml:space="preserve">○ Gettext: skipped (:gettext not installed)</tspan></text>
+  <text x="22" y="215"><tspan fill="#6e7681" xml:space="preserve">○ Sobelow: skipped (:sobelow not installed)</tspan></text>
+  <text x="22" y="235"><tspan fill="#3fb950" xml:space="preserve">✓ Doctor:</tspan><tspan xml:space="preserve"> Passed (519ms)</tspan></text>
+  <text x="22" y="255"><tspan fill="#3fb950" xml:space="preserve">✓ Credo:</tspan><tspan xml:space="preserve"> No issues (775ms)</tspan></text>
+  <text x="22" y="275"><tspan fill="#ff7b72" xml:space="preserve">✗ Dependencies: 1 vulnerability (1 moderate) (2.5s)</tspan></text>
+  <text x="22" y="295"><tspan fill="#3fb950" xml:space="preserve">✓ Tests:</tspan><tspan xml:space="preserve"> 345 of 345 passed (4.1s)</tspan></text>
+  <text x="22" y="335"><tspan xml:space="preserve">────────────────────────────────────────────────────────────</tspan></text>
+  <text x="22" y="355"><tspan fill="#ff7b72" xml:space="preserve">Dependencies - FAILED</tspan></text>
+  <text x="22" y="375"><tspan xml:space="preserve">────────────────────────────────────────────────────────────</tspan></text>
+  <text x="22" y="395"><tspan xml:space="preserve">mix.lock</tspan></text>
+  <text x="22" y="415"><tspan xml:space="preserve">  -  [error] decimal 2.3.0: Unbounded exponent in `Decimal.new` enables</tspan></text>
+  <text x="22" y="435"><tspan xml:space="preserve">     unauthenticated DoS (moderate severity, patched in 3.0.0) (GHSA-rhv4-8758-jx7v)</tspan></text>
+  </g>
+</svg>

--- a/mix.exs
+++ b/mix.exs
@@ -57,11 +57,13 @@ defmodule ExQuality.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      # Only the one asset the README references. hex.pm renders the README
-      # from the tarball and resolves its relative paths against it, so the
-      # mark has to ship or the package page shows a broken image. The rest of
-      # `assets` stays out: HexDocs is built from the checkout at publish time,
-      # so it reaches the docs without every dependent downloading it.
+      # Only the one asset the README references by a relative path. hex.pm
+      # renders the README from the tarball and resolves its relative paths
+      # against it, so the mark has to ship or the package page shows a broken
+      # image. The example-output image is referenced by absolute URL for that
+      # same reason and so does not ship. The rest of `assets` stays out:
+      # HexDocs is built from the checkout at publish time, so it reaches the
+      # docs without every dependent downloading it.
       files:
         ~w(lib docs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md usage-rules.md assets/ex_quality.svg)
     ]


### PR DESCRIPTION
0.13.0 added colour to the stage status lines, but the README's example output
is a fenced code block, and neither GitHub nor HexDocs renders ANSI inside one.
The section called "The output is the point" was showing the shape of a run
without the thing the release changed.

It is an SVG now. Hand-written rather than screenshotted, so the colours are
the ones `ExQuality.Printer` actually emits (green tick and stage name, dim
skip line, red failure via `Mix.Shell.IO.error/1`) and the findings below stay
uncoloured because `Finding.render/1` does not colour them.

A line under the image says colour is a second channel over the `✓`/`○`/`✗` and
is dropped when the output is not a terminal, so nobody reads the image as a
promise about CI logs.

The image is referenced by absolute `raw.githubusercontent.com` URL. That is the
same reasoning as the guide links in #58: hex.pm resolves a README's relative
paths against the tarball, so a relative reference would have to ship in
`files:` and grow the download for every dependent. `mix.exs` has a note to that
effect now, since its existing comment claimed the mark was the only asset the
README referenced.

Rendered check of the SVG is attached below - padding, glyph rendering and the
monospace column all verified at the committed size (732x464).